### PR TITLE
DAC6-2554: Add clientTradingName to email params

### DIFF
--- a/app/models/email/EmailRequest.scala
+++ b/app/models/email/EmailRequest.scala
@@ -29,7 +29,7 @@ object EmailRequest {
                            submissionTime: String,
                            messageRefId: String,
                            cbcId: Option[String],
-                           clientTradingName: Option[String]
+                           tradingName: Option[String]
   ): EmailRequest = {
 
     val contactName = name.fold("Registrant")(name => name)
@@ -41,7 +41,7 @@ object EmailRequest {
         "dateSubmitted" -> submissionTime,
         "messageRefId"  -> messageRefId,
         "contactName"   -> contactName
-      ) ++ cbcId.map("cbcId" -> _) ++ clientTradingName.map("clientTradingName" -> _)
+      ) ++ cbcId.map("cbcId" -> _) ++ tradingName.map("clientTradingName" -> _)
     )
   }
 }

--- a/app/models/email/EmailRequest.scala
+++ b/app/models/email/EmailRequest.scala
@@ -23,14 +23,25 @@ case class EmailRequest(to: List[String], templateId: String, parameters: Map[St
 object EmailRequest {
   implicit val format: OFormat[EmailRequest] = Json.format[EmailRequest]
 
-  def fileUploadSubmission(email: String, name: Option[String], emailTemplate: String, submissionTime: String, messageRefId: String, cbcId: Option[String]): EmailRequest = {
+  def fileUploadSubmission(email: String,
+                           name: Option[String],
+                           emailTemplate: String,
+                           submissionTime: String,
+                           messageRefId: String,
+                           cbcId: Option[String],
+                           clientTradingName: Option[String]
+  ): EmailRequest = {
 
     val contactName = name.fold("Registrant")(name => name)
 
     EmailRequest(
       List(email),
       emailTemplate,
-      Map("dateSubmitted" -> submissionTime, "messageRefId" -> messageRefId, "contactName" -> contactName) ++ cbcId.map("cbcId" -> _)
+      Map(
+        "dateSubmitted" -> submissionTime,
+        "messageRefId"  -> messageRefId,
+        "contactName"   -> contactName
+      ) ++ cbcId.map("cbcId" -> _) ++ clientTradingName.map("clientTradingName" -> _)
     )
   }
 }

--- a/app/models/email/EmailRequest.scala
+++ b/app/models/email/EmailRequest.scala
@@ -41,7 +41,7 @@ object EmailRequest {
         "dateSubmitted" -> submissionTime,
         "messageRefId"  -> messageRefId,
         "contactName"   -> contactName
-      ) ++ cbcId.map("cbcId" -> _) ++ tradingName.map("clientTradingName" -> _)
+      ) ++ cbcId.map("cbcId" -> _) ++ tradingName.filter(_.nonEmpty).map("clientTradingName" -> _)
     )
   }
 }

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -68,7 +68,7 @@ class EmailService @Inject()(emailConnector: EmailConnector, emailTemplate: Emai
         val agentSecondaryEmail   = agentDetails.flatMap(_.subscriptionDetails.secondaryContact.map(_.email))
         val agentSecondaryName    = agentDetails.flatMap(_.subscriptionDetails.secondaryContact.map(_.organisationDetails.organisationName))
         val cbcId                 = responseDetail.subscriptionID
-        val clientTradingName     = responseDetail.tradingName
+        val tradingName           = responseDetail.tradingName
 
         lazy val orgEmails: Seq[Future[EmailResult]] = Seq(
           send(emailAddress, contactName, emailTemplate.getOrganisationTemplate(isUploadSuccessful), submissionTime, messageRefId, None, None)
@@ -84,7 +84,7 @@ class EmailService @Inject()(emailConnector: EmailConnector, emailTemplate: Emai
                submissionTime,
                messageRefId,
                Some(cbcId),
-               clientTradingName
+              tradingName
           ).map(res => EmailResult("Primary Agent", res)),
           send(agentSecondaryEmail,
                agentSecondaryName,
@@ -92,7 +92,7 @@ class EmailService @Inject()(emailConnector: EmailConnector, emailTemplate: Emai
                submissionTime,
                messageRefId,
                Some(cbcId),
-               clientTradingName
+               tradingName
           ).map(res => EmailResult("Secondary Agent", res))
         )
 
@@ -119,14 +119,14 @@ class EmailService @Inject()(emailConnector: EmailConnector, emailTemplate: Emai
                    submissionTime: String,
                    messageRefId: String,
                    cbcId: Option[String],
-                   clientTradingName: Option[String]
+                   tradingName: Option[String]
   )(implicit hc: HeaderCarrier): Future[Option[HttpResponse]] = {
     emailAddress
       .filter(EmailAddress.isValid)
       .map { email =>
         emailConnector
           .sendEmail(
-            EmailRequest.fileUploadSubmission(email, contactName, template, submissionTime, messageRefId, cbcId, clientTradingName)
+            EmailRequest.fileUploadSubmission(email, contactName, template, submissionTime, messageRefId, cbcId, tradingName)
           )
           .map(Some.apply)
       }

--- a/app/utils/DateTimeFormatUtil.scala
+++ b/app/utils/DateTimeFormatUtil.scala
@@ -26,7 +26,8 @@ object DateTimeFormatUtil {
   val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy")
   val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("h:mma")
 
-  def displayFormattedDate(dateTime: LocalDateTime): String =
-    s"${dateTime.atZone(euLondonZoneId).format(dateFormatter).capitalize} at ${dateTime.atZone(euLondonZoneId).format(timeFormatter)}"
+  def displayFormattedDate(dateTime: LocalDateTime): String = {
+    s"${dateTime.atZone(euLondonZoneId).format(timeFormatter)} on ${dateTime.atZone(euLondonZoneId).format(dateFormatter).capitalize}"
+  }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import uk.gov.hmrc.DefaultBuildSettings.integrationTestSettings
-import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 
 val appName = "country-by-country-reporting"
 
@@ -20,7 +19,6 @@ lazy val microservice = Project(appName, file("."))
     )
   )
   .settings(scoverageSettings)
-  .settings(publishingSettings: _*)
   .configs(IntegrationTest)
   .settings(integrationTestSettings(): _*)
   .settings(resolvers += Resolver.jcenterRepo)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -98,7 +98,6 @@ metrics {
 
 auditing {
   enabled = true
-  traceRequests = true
   consumer {
     baseUri {
       host = localhost


### PR DESCRIPTION
This PR:
- Updates the displayFormattedDate from `20 March 2023 at 11:14am` to `11:14am on 20 March 2023`
- Adds the client `tradingName` to the email params

The new date format is required by all the CDC email templates while the client trading name is required by the new CBC agent email templates. 