### PR TITLE
DAC6-2955: Added custom error for TIN length

### DIFF
--- a/app/helpers/XmlErrorMessageHelper.scala
+++ b/app/helpers/XmlErrorMessageHelper.scala
@@ -146,10 +146,12 @@ class XmlErrorMessageHelper extends SaxParseErrorRegExConstants {
             Some(Message("xml.not.corrMessageRefId"))
           case missingOrInvalidErrorFormat(_, "SendingEntityIN") =>
             Some(Message("xml.SendingEntityIN.length"))
+          case genericInvalidSecondErrorFormat("TIN") =>
+            Some(Message("xml.TIN.length"))
           case missingOrInvalidErrorFormat(_, element) =>
             Some(Message("xml.not.allowed.length", Seq(element, numberFormatter.format(allowedLength.toInt))))
           case genericInvalidSecondErrorFormat(element) =>
-              Some(Message("xml.not.allowed.length", Seq(element, numberFormatter.format(allowedLength.toInt))))
+            Some(Message("xml.not.allowed.length", Seq(element, numberFormatter.format(allowedLength.toInt))))
           case _ => None
         }
       case _ => None

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.12.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.18.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.2.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.18")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.0.6")

--- a/test/helpers/XmlErrorMessageHelperSpec.scala
+++ b/test/helpers/XmlErrorMessageHelperSpec.scala
@@ -152,7 +152,7 @@ class XmlErrorMessageHelperSpec extends SpecBase {
           val error2 = SaxParseError(lineNumber, "cvc-complex-type.2.2: Element 'cbc:TIN' must have no element [children], and the value must be valid.")
 
           val result = helper.generateErrorMessages(ListBuffer(error1, error2))
-          result mustBe List(GenericError(lineNumber, Message("xml.not.allowed.length", List("TIN", "200"))))
+          result mustBe List(GenericError(lineNumber, Message("xml.TIN.length")))
         }
 
         "must return correct error for missing org name'" in {
@@ -551,7 +551,7 @@ class XmlErrorMessageHelperSpec extends SpecBase {
           val error2 = SaxParseError(lineNumber, "cvc-complex-type.2.2: Element 'TIN' must have no element [children], and the value must be valid.")
 
           val result = helper.generateErrorMessages(ListBuffer(error1, error2))
-          result mustBe List(GenericError(lineNumber, Message("xml.not.allowed.length", List("TIN", "200"))))
+          result mustBe List(GenericError(lineNumber, Message("xml.TIN.length")))
         }
 
         "must return correct error for missing org name'" in {


### PR DESCRIPTION
Return a custom error key if a TIN is too long.

Allows us to display a custom error message on the frontend:

https://github.com/hmrc/country-by-country-reporting-frontend/pull/232