### PR TITLE
DAC6-2966: Determine report type for valid XML submission

### DIFF
--- a/app/models/submission/MessageSpecData.scala
+++ b/app/models/submission/MessageSpecData.scala
@@ -22,7 +22,6 @@ sealed trait MessageTypeIndic
 case object CBC401 extends MessageTypeIndic
 case object CBC402 extends MessageTypeIndic
 
-
 object MessageTypeIndic {
 
   def fromString(typeIndic: String): MessageTypeIndic = typeIndic.toUpperCase match {
@@ -42,7 +41,32 @@ object MessageTypeIndic {
   }
 }
 
-case class MessageSpecData(messageRefId: String, messageTypeIndic: MessageTypeIndic, reportingEntityName: String)
+sealed trait ReportType
+case object TestData extends ReportType
+case object NewInformation extends ReportType
+case object DeletionOfAllInformation extends ReportType
+case object NewInformationForExistingReport extends ReportType
+case object CorrectionForExistingReport extends ReportType
+case object DeletionForExistingReport extends ReportType
+case object CorrectionAndDeletionForExistingReport extends ReportType
+case object CorrectionForReportingEntity extends ReportType
+
+object ReportType {
+  implicit val format: OFormat[ReportType] = {
+    implicit def testDataFormats: OFormat[TestData.type] = Json.format[TestData.type]
+    implicit def newInfoFormats: OFormat[NewInformation.type] = Json.format[NewInformation.type]
+    implicit def deletionFormats: OFormat[DeletionOfAllInformation.type] = Json.format[DeletionOfAllInformation.type]
+    implicit def newInfoForExistingFormats: OFormat[NewInformationForExistingReport.type] = Json.format[NewInformationForExistingReport.type]
+    implicit def correctionForExistingFormats: OFormat[CorrectionForExistingReport.type] = Json.format[CorrectionForExistingReport.type]
+    implicit def deletionForExistingFormats: OFormat[DeletionForExistingReport.type] = Json.format[DeletionForExistingReport.type]
+    implicit def correctionAndDeletionForExistingFormats: OFormat[CorrectionAndDeletionForExistingReport.type] = Json.format[CorrectionAndDeletionForExistingReport.type]
+    implicit def correctionFormats: OFormat[CorrectionForReportingEntity.type] = Json.format[CorrectionForReportingEntity.type]
+
+    Json.format[ReportType]
+  }
+}
+
+case class MessageSpecData(messageRefId: String, messageTypeIndic: MessageTypeIndic, reportingEntityName: String, reportType: ReportType = CorrectionForReportingEntity)
 
 object MessageSpecData {
   implicit val format: OFormat[MessageSpecData] = Json.format[MessageSpecData]

--- a/app/models/submission/MessageSpecData.scala
+++ b/app/models/submission/MessageSpecData.scala
@@ -52,21 +52,31 @@ case object CorrectionAndDeletionForExistingReport extends ReportType
 case object CorrectionForReportingEntity extends ReportType
 
 object ReportType {
-  implicit val format: OFormat[ReportType] = {
-    implicit def testDataFormats: OFormat[TestData.type] = Json.format[TestData.type]
-    implicit def newInfoFormats: OFormat[NewInformation.type] = Json.format[NewInformation.type]
-    implicit def deletionFormats: OFormat[DeletionOfAllInformation.type] = Json.format[DeletionOfAllInformation.type]
-    implicit def newInfoForExistingFormats: OFormat[NewInformationForExistingReport.type] = Json.format[NewInformationForExistingReport.type]
-    implicit def correctionForExistingFormats: OFormat[CorrectionForExistingReport.type] = Json.format[CorrectionForExistingReport.type]
-    implicit def deletionForExistingFormats: OFormat[DeletionForExistingReport.type] = Json.format[DeletionForExistingReport.type]
-    implicit def correctionAndDeletionForExistingFormats: OFormat[CorrectionAndDeletionForExistingReport.type] = Json.format[CorrectionAndDeletionForExistingReport.type]
-    implicit def correctionFormats: OFormat[CorrectionForReportingEntity.type] = Json.format[CorrectionForReportingEntity.type]
+  implicit val writes: Writes[ReportType] = Writes[ReportType] {
+    case TestData => JsString("TEST_DATA")
+    case NewInformation => JsString("NEW_INFORMATION")
+    case DeletionOfAllInformation => JsString("DELETION_OF_ALL_INFORMATION")
+    case NewInformationForExistingReport => JsString("NEW_INFORMATION_FOR_EXISTING_REPORT")
+    case CorrectionForExistingReport => JsString("CORRECTION_FOR_EXISTING_REPORT")
+    case DeletionForExistingReport => JsString("DELETION_FOR_EXISTING_REPORT")
+    case CorrectionAndDeletionForExistingReport => JsString("CORRECTION_AND_DELETION_FOR_EXISTING_REPORT")
+    case CorrectionForReportingEntity => JsString("CORRECTION_FOR_REPORTING_ENTITY")
+  }
 
-    Json.format[ReportType]
+  implicit val reads: Reads[ReportType] = Reads[ReportType] {
+    case JsString("TEST_DATA") => JsSuccess(TestData)
+    case JsString("NEW_INFORMATION") => JsSuccess(NewInformation)
+    case JsString("DELETION_OF_ALL_INFORMATION") => JsSuccess(DeletionOfAllInformation)
+    case JsString("NEW_INFORMATION_FOR_EXISTING_REPORT") => JsSuccess(NewInformationForExistingReport)
+    case JsString("CORRECTION_FOR_EXISTING_REPORT") => JsSuccess(CorrectionForExistingReport)
+    case JsString("DELETION_FOR_EXISTING_REPORT") => JsSuccess(DeletionForExistingReport)
+    case JsString("CORRECTION_AND_DELETION_FOR_EXISTING_REPORT") => JsSuccess(CorrectionAndDeletionForExistingReport)
+    case JsString("CORRECTION_FOR_REPORTING_ENTITY") => JsSuccess(CorrectionForReportingEntity)
+    case value              => JsError(s"Unexpected value of _type: $value")
   }
 }
 
-case class MessageSpecData(messageRefId: String, messageTypeIndic: MessageTypeIndic, reportingEntityName: String, reportType: ReportType = CorrectionForReportingEntity)
+case class MessageSpecData(messageRefId: String, messageTypeIndic: MessageTypeIndic, reportingEntityName: String, reportType: ReportType)
 
 object MessageSpecData {
   implicit val format: OFormat[MessageSpecData] = Json.format[MessageSpecData]

--- a/app/services/DataExtraction.scala
+++ b/app/services/DataExtraction.scala
@@ -16,10 +16,10 @@
 
 package services
 
-import models.submission.{MessageSpecData, MessageTypeIndic}
+import models.submission._
 
 import javax.inject.Inject
-import scala.xml.Elem
+import scala.xml.{Elem, NodeSeq}
 
 @Inject
 class DataExtraction()() {
@@ -31,5 +31,37 @@ class DataExtraction()() {
       typeIndic <- (xml \\ "MessageTypeIndic").headOption.map(node => MessageTypeIndic.fromString(node.text))
       reportingEntityName <- (xml \\ "ReportingEntity" \\ "Entity" \\ "Name").headOption
     } yield MessageSpecData(messageID.text, typeIndic, reportingEntityName.text)
+
+  def getReportType(messageTypeIndicator: MessageTypeIndic, xml: Elem): ReportType = {
+    val allDocTypeIndicators: Seq[String] = (xml \\ "DocTypeIndic").map(node => node.text)
+    val reportingEntityDocTypeIndicators = (xml \\ "ReportingEntity" \\ "DocTypeIndic").map(node => node.text)
+    val cbcReportAndAdditionalInfoSections = xml \\ "CbcReports" ++ xml \\ "AdditionalInfo"
+
+    val testDataIndicators: Seq[String] = List("OECD10", "OECD11", "OECD12", "OECD13")
+
+    if (allDocTypeIndicators.exists(indic => testDataIndicators.contains(indic))) {
+      TestData
+    }
+    else if (messageTypeIndicator == CBC401) {
+      NewInformation
+    }
+    else if (reportingEntityDocTypeIndicators.contains("OECD3")) {
+      DeletionOfAllInformation
+    }
+    else if (cbcReportAndAdditionalInfoSections.nonEmpty) {
+      val docTypeIndicators: NodeSeq = cbcReportAndAdditionalInfoSections \\ "DocTypeIndic"
+      val uniqueDocTypes = docTypeIndicators.map(node => node.text).distinct
+
+      (uniqueDocTypes.length, uniqueDocTypes.headOption) match {
+        case (1, Some("OECD1")) => NewInformationForExistingReport
+        case (1, Some("OECD2")) => CorrectionForExistingReport
+        case (1, Some("OECD3")) => DeletionForExistingReport
+        case _ => CorrectionAndDeletionForExistingReport
+      }
+    }
+    else {
+      CorrectionForReportingEntity
+    }
+  }
 
 }

--- a/app/services/DataExtraction.scala
+++ b/app/services/DataExtraction.scala
@@ -30,7 +30,7 @@ class DataExtraction()() {
       messageID <- (xml \\ "MessageRefId").headOption
       typeIndic <- (xml \\ "MessageTypeIndic").headOption.map(node => MessageTypeIndic.fromString(node.text))
       reportingEntityName <- (xml \\ "ReportingEntity" \\ "Entity" \\ "Name").headOption
-    } yield MessageSpecData(messageID.text, typeIndic, reportingEntityName.text)
+    } yield MessageSpecData(messageID.text, typeIndic, reportingEntityName.text, getReportType(typeIndic, xml))
 
   def getReportType(messageTypeIndicator: MessageTypeIndic, xml: Elem): ReportType = {
     val allDocTypeIndicators: Seq[String] = (xml \\ "DocTypeIndic").map(node => node.text)

--- a/test/models/submission/MessageSpecDataSpec.scala
+++ b/test/models/submission/MessageSpecDataSpec.scala
@@ -17,37 +17,98 @@
 package models.submission
 
 import base.SpecBase
-import play.api.libs.json.{JsResultException, Json}
+import play.api.libs.json.{JsResultException, JsString, Json}
 
 class MessageSpecDataSpec extends SpecBase {
 
   "MessageSpecDataSpec" - {
     "must serialize MessageSpec for MessageTypeIndic CBC401" in {
-      val msd          = MessageSpecData("XDSG111111", CBC401, "Reporting Entity")
-      val expectedJson = Json.parse("""{"messageRefId":"XDSG111111","messageTypeIndic":"CBC401","reportingEntityName":"Reporting Entity"}""")
+      val msd          = MessageSpecData("XDSG111111", CBC401, "Reporting Entity", NewInformation)
+      val expectedJson = Json.parse("""{"messageRefId":"XDSG111111","messageTypeIndic":"CBC401","reportingEntityName":"Reporting Entity","reportType":"NEW_INFORMATION"}""")
       Json.toJson(msd) mustBe expectedJson
     }
     "must deserialize MessageSpec for MessageTypeIndic CBC401" in {
-      val json     = Json.parse("""{"messageRefId":"XDSG333333","messageTypeIndic":"CBC401","reportingEntityName":"Reporting Entity"}""")
-      val expected = MessageSpecData("XDSG333333", CBC401, "Reporting Entity")
+      val json     = Json.parse("""{"messageRefId":"XDSG333333","messageTypeIndic":"CBC401","reportingEntityName":"Reporting Entity","reportType":"NEW_INFORMATION"}""")
+      val expected = MessageSpecData("XDSG333333", CBC401, "Reporting Entity", NewInformation)
 
       json.as[MessageSpecData] mustEqual expected
     }
     "must serialize MessageSpec for MessageTypeIndic CBC402" in {
-      val msd = MessageSpecData("XDSG111111", CBC402, "Reporting Entity")
-      val expectedJson = Json.parse("""{"messageRefId":"XDSG111111","messageTypeIndic":"CBC402","reportingEntityName":"Reporting Entity"}""")
+      val msd = MessageSpecData("XDSG111111", CBC402, "Reporting Entity", NewInformation)
+      val expectedJson = Json.parse("""{"messageRefId":"XDSG111111","messageTypeIndic":"CBC402","reportingEntityName":"Reporting Entity","reportType":"NEW_INFORMATION"}""")
       Json.toJson(msd) mustBe expectedJson
     }
     "must deserialize MessageSpec for MessageTypeIndic CBC402" in {
-      val json = Json.parse("""{"messageRefId":"XDSG333333","messageTypeIndic":"CBC402","reportingEntityName":"Reporting Entity"}""")
-      val expected = MessageSpecData("XDSG333333", CBC402, "Reporting Entity")
+      val json = Json.parse("""{"messageRefId":"XDSG333333","messageTypeIndic":"CBC402","reportingEntityName":"Reporting Entity","reportType":"NEW_INFORMATION"}""")
+      val expected = MessageSpecData("XDSG333333", CBC402, "Reporting Entity", NewInformation)
 
       json.as[MessageSpecData] mustEqual expected
     }
     "must fail to deserialize for any other MessageTypeIndic value" in {
-      val json = Json.parse("""{"messageRefId":"XDSG333333","messageTypeIndic":"CBC123","reportingEntityName":"Reporting Entity"}""")
+      val json = Json.parse("""{"messageRefId":"XDSG333333","messageTypeIndic":"CBC123","reportingEntityName":"Reporting Entity","reportType":"NEW_INFORMATION"}""")
 
       a [JsResultException] must be thrownBy(json.as[MessageSpecData])
     }
+  }
+
+  "ReportType" - {
+
+    "serialization" - {
+      "must serialize TestData" in {
+        Json.toJson[ReportType](TestData) mustBe JsString("TEST_DATA")
+      }
+      "must serialize NewInformation" in {
+        Json.toJson[ReportType](NewInformation) mustBe JsString("NEW_INFORMATION")
+      }
+      "must serialize DeletionOfAllInformation" in {
+        Json.toJson[ReportType](DeletionOfAllInformation) mustBe JsString("DELETION_OF_ALL_INFORMATION")
+      }
+      "must serialize NewInformationForExistingReport" in {
+        Json.toJson[ReportType](NewInformationForExistingReport) mustBe JsString("NEW_INFORMATION_FOR_EXISTING_REPORT")
+      }
+      "must serialize CorrectionForExistingReport" in {
+        Json.toJson[ReportType](CorrectionForExistingReport) mustBe JsString("CORRECTION_FOR_EXISTING_REPORT")
+      }
+      "must serialize DeletionForExistingReport" in {
+        Json.toJson[ReportType](DeletionForExistingReport) mustBe JsString("DELETION_FOR_EXISTING_REPORT")
+      }
+      "must serialize CorrectionAndDeletionForExistingReport" in {
+        Json.toJson[ReportType](CorrectionAndDeletionForExistingReport) mustBe JsString("CORRECTION_AND_DELETION_FOR_EXISTING_REPORT")
+      }
+      "must serialize CorrectionForReportingEntity" in {
+        Json.toJson[ReportType](CorrectionForReportingEntity) mustBe JsString("CORRECTION_FOR_REPORTING_ENTITY")
+      }
+    }
+
+    "deserialization" - {
+      "must deserialize TestData" in {
+        JsString("TEST_DATA").as[ReportType] mustBe TestData
+      }
+      "must deserialize NewInformation" in {
+        JsString("NEW_INFORMATION").as[ReportType] mustBe NewInformation
+      }
+      "must deserialize DeletionOfAllInformation" in {
+        JsString("DELETION_OF_ALL_INFORMATION").as[ReportType] mustBe DeletionOfAllInformation
+      }
+      "must deserialize NewInformationForExistingReport" in {
+        JsString("NEW_INFORMATION_FOR_EXISTING_REPORT").as[ReportType] mustBe NewInformationForExistingReport
+      }
+      "must deserialize CorrectionForExistingReport" in {
+        JsString("CORRECTION_FOR_EXISTING_REPORT").as[ReportType] mustBe CorrectionForExistingReport
+      }
+      "must deserialize DeletionForExistingReport" in {
+        JsString("DELETION_FOR_EXISTING_REPORT").as[ReportType] mustBe DeletionForExistingReport
+      }
+      "must deserialize CorrectionAndDeletionForExistingReport" in {
+        JsString("CORRECTION_AND_DELETION_FOR_EXISTING_REPORT").as[ReportType] mustBe CorrectionAndDeletionForExistingReport
+      }
+      "must deserialize CorrectionForReportingEntity" in {
+        JsString("CORRECTION_FOR_REPORTING_ENTITY").as[ReportType] mustBe CorrectionForReportingEntity
+      }
+      "must not deserialize an invalid report type" in {
+        a[JsResultException] must be thrownBy (JsString("ReportType").as[ReportType])
+      }
+    }
+
   }
 }

--- a/test/services/DataExtractionSpec.scala
+++ b/test/services/DataExtractionSpec.scala
@@ -17,9 +17,9 @@
 package services
 
 import base.SpecBase
-import models.submission.{CBC401, MessageSpecData}
+import models.submission.{CBC401, CBC402, CorrectionAndDeletionForExistingReport, CorrectionForExistingReport, CorrectionForReportingEntity, DeletionForExistingReport, DeletionOfAllInformation, MessageSpecData, NewInformation, NewInformationForExistingReport, ReportType, TestData}
 
-import scala.xml.{Elem, NodeSeq}
+import scala.xml.Elem
 
 class DataExtractionSpec extends SpecBase {
 
@@ -47,7 +47,7 @@ class DataExtractionSpec extends SpecBase {
 
       val xml: Elem = {
         <file>
-          <MessageTypeIndic>CBC401</MessageTypeIndic>
+          <MessageTypeIndic></MessageTypeIndic>
           <ReportingEntity>
             <Entity>
               <Name>Name</Name>
@@ -55,8 +55,160 @@ class DataExtractionSpec extends SpecBase {
           </ReportingEntity>
         </file>
       }
-      
+
       dataExtraction.messageSpecData(xml) mustBe None
+    }
+  }
+
+  "getReportType" - {
+
+    def generateReportXml(
+      reportingEntityDocTypeIndic: List[Option[String]] = List(None),
+      cbcReportDocTypeIndic: List[Option[String]] = List(),
+      additionalInfoDocTypeIndic: List[Option[String]] = List()
+    ):Elem = {
+      <CBC_OECD xmlns="urn:oecd:ties:cbc:v2" xmlns:urn1="urn:oecd:ties:cbcstf:v5">
+        {reportingEntityDocTypeIndic.map(reportingEntityIndic =>
+          <CbcBody>
+            <ReportingEntity>
+              {if (reportingEntityIndic.nonEmpty) {
+                <DocSpec>
+                  <urn1:DocTypeIndic>{reportingEntityIndic.get}</urn1:DocTypeIndic>
+                </DocSpec>
+              }}
+            </ReportingEntity>
+            {cbcReportDocTypeIndic.map(cbcReportIndic =>
+              <CbcReports>
+                {if (cbcReportIndic.nonEmpty) {
+                  <DocSpec>
+                    <urn1:DocTypeIndic>{cbcReportIndic.get}</urn1:DocTypeIndic>
+                  </DocSpec>
+                }}
+              </CbcReports>
+            )}
+            {additionalInfoDocTypeIndic.map(additionalInfoIndic =>
+              <AdditionalInfo>
+                {if (additionalInfoIndic.nonEmpty) {
+                  <DocSpec>
+                    <urn1:DocTypeIndic>{additionalInfoIndic.get}</urn1:DocTypeIndic>
+                  </DocSpec>
+                }}
+              </AdditionalInfo>
+            )}
+          </CbcBody>
+        )}
+      </CBC_OECD>
+    }
+
+    "must return TestDataReportType if any DocTypeIndic values are one of the test values" - {
+      List("OECD10", "OECD11", "OECD12", "OECD13").foreach { code =>
+        s"DocTypeIndic ${code} in ReportingEntity returns TestDataReportType" in {
+          val xml = generateReportXml(
+            reportingEntityDocTypeIndic = List(Some(code)),
+            cbcReportDocTypeIndic = List(Some("OECD1"), Some("OECD2")),
+            additionalInfoDocTypeIndic = List(Some("OECD3"))
+          )
+
+          dataExtraction.getReportType(CBC402, xml) mustBe TestData
+        }
+        s"DocTypeIndic ${code} in CbcReports returns TestDataReportType" in {
+          val xml = generateReportXml(
+            reportingEntityDocTypeIndic = List(Some("OECD1")),
+            cbcReportDocTypeIndic = List(Some(code), Some("OECD2")),
+            additionalInfoDocTypeIndic = List(Some("OECD3"))
+          )
+
+          dataExtraction.getReportType(CBC402, xml) mustBe TestData
+        }
+        s"DocTypeIndic ${code} in AdditionalInfo returns TestDataReportType" in {
+          val xml = generateReportXml(
+            reportingEntityDocTypeIndic = List(Some("OECD1")),
+            cbcReportDocTypeIndic = List(Some("OECD2"), Some("OECD3")),
+            additionalInfoDocTypeIndic = List(Some(code))
+          )
+
+          dataExtraction.getReportType(CBC402, xml) mustBe TestData
+        }
+      }
+    }
+
+    "must return NewInformationReportType if the MessageTypeIndic is CBC401" in {
+      val xml = generateReportXml()
+
+      dataExtraction.getReportType(CBC401, xml) mustBe NewInformation
+    }
+
+    "must return DeletionOfAllPreviousInformationReportType if any ReportingEntity DocTypeIndic is OECD3" in {
+      val xml = generateReportXml(
+        reportingEntityDocTypeIndic = List(None, Some("Y"), Some("OECD3"))
+      )
+
+      dataExtraction.getReportType(CBC402, xml) mustBe DeletionOfAllInformation
+    }
+
+    "must return CorrectionsAndDeletionsForExistingReportType if there is at least one CbcReports element" in {
+      val xml = generateReportXml(
+        cbcReportDocTypeIndic = List(None)
+      )
+
+      dataExtraction.getReportType(CBC402, xml) mustBe CorrectionAndDeletionForExistingReport
+    }
+
+    "must return CorrectionsAndDeletionsForExistingReportType if there is at least one AdditionalInfo element" in {
+      val xml = generateReportXml(
+        additionalInfoDocTypeIndic = List(None)
+      )
+
+      dataExtraction.getReportType(CBC402, xml) mustBe CorrectionAndDeletionForExistingReport
+    }
+
+    "must return NewInformationForExistingReport if all the DocTypeIndic values in CbcReports or AdditionalInfo are OECD1" in  {
+      val xml = generateReportXml(
+        cbcReportDocTypeIndic = List(Some("OECD1"), None),
+        additionalInfoDocTypeIndic = List(Some("OECD1"))
+      )
+
+      dataExtraction.getReportType(CBC402, xml) mustBe NewInformationForExistingReport
+    }
+
+    "must return CorrectionsForExistingReportType if all the DocTypeIndic values in CbcReports or AdditionalInfo are OECD2" in  {
+      val xml = generateReportXml(
+        cbcReportDocTypeIndic = List(Some("OECD2"), Some("OECD2"), Some("OECD2"))
+      )
+
+      dataExtraction.getReportType(CBC402, xml) mustBe CorrectionForExistingReport
+    }
+
+    "must return DeletionForExistingReport if all the DocTypeIndic values in CbcReports or AdditionalInfo are OECD3" in  {
+      val xml = generateReportXml(
+        additionalInfoDocTypeIndic = List(Some("OECD3"), None)
+      )
+
+      dataExtraction.getReportType(CBC402, xml) mustBe DeletionForExistingReport
+    }
+
+    "must return CorrectionAndDeletionForExistingReport if the DocTypeIndic values in CbcReports or AdditionalInfo are mixed" in  {
+      val xml = generateReportXml(
+        cbcReportDocTypeIndic = List(Some("OECD1"), Some("OECD1"), Some("OECD2")),
+        additionalInfoDocTypeIndic = List(Some("OECD1"))
+      )
+
+      dataExtraction.getReportType(CBC402, xml) mustBe CorrectionAndDeletionForExistingReport
+    }
+
+    "must return CorrectionAndDeletionForExistingReport if there are no DocTypeIndic values in CbcReports or AdditionalInfo" in  {
+      val xml = generateReportXml(
+        cbcReportDocTypeIndic = List(None, None),
+        additionalInfoDocTypeIndic = List(None)
+      )
+
+      dataExtraction.getReportType(CBC402, xml) mustBe CorrectionAndDeletionForExistingReport
+    }
+
+    "must return CorrectionForReportingEntity if none of the conditions above are met" in {
+      val xml = generateReportXml()
+
+      dataExtraction.getReportType(CBC402, xml) mustBe CorrectionForReportingEntity
     }
   }
 }

--- a/test/services/validation/UploadedXmlValidationEngineSpec.scala
+++ b/test/services/validation/UploadedXmlValidationEngineSpec.scala
@@ -19,7 +19,7 @@ package services.validation
 import base.SpecBase
 import config.AppConfig
 import helpers.XmlErrorMessageHelper
-import models.submission.{CBC401, MessageSpecData}
+import models.submission.{CBC401, MessageSpecData, NewInformation}
 import models.validation._
 import org.mockito.ArgumentMatchers.any
 import services.DataExtraction
@@ -35,7 +35,7 @@ class UploadedXmlValidationEngineSpec extends SpecBase {
   val defaultError                        = "There is a problem with this line number"
   val lineNumber                          = 0
   val noErrors: ListBuffer[SaxParseError] = ListBuffer()
-  val messageSpecData: MessageSpecData    = MessageSpecData("XBC99999999999", CBC401, "Reporting Entity")
+  val messageSpecData: MessageSpecData    = MessageSpecData("XBC99999999999", CBC401, "Reporting Entity", NewInformation)
 
   val addressError1: SaxParseError = SaxParseError(20,
                                                    "cvc-minLength-valid: Value '' with length = '0' is " +


### PR DESCRIPTION
If a XML file has been uploaded and successfully schema validated, we will try and determine what sort of report the user has submitted based on key information in the XML itself.

This is then stored in the DB to be retrieved later / inform the frontend journey.