### PR TITLE
DAC6-2979: Amended error code parsing to allow "CBC Error Code" format

### DIFF
--- a/app/models/xml/FileErrorCode.scala
+++ b/app/models/xml/FileErrorCode.scala
@@ -68,7 +68,7 @@ object FileErrorCode {
       values.find(x => x.code == xml.text) match {
         case Some(errorCode) => ParseSuccess(errorCode)
         case None =>
-          try ParseSuccess(UnknownFileErrorCode(Integer.parseInt(xml.text).toString))
+          try ParseSuccess(UnknownFileErrorCode(xml.text))
           catch {
             case _: Exception => ParseFailure(FileErrorCodeParseError(s"Invalid or missing FileErrorCode: ${xml.text}"))
           }

--- a/app/models/xml/RecordErrorCode.scala
+++ b/app/models/xml/RecordErrorCode.scala
@@ -82,7 +82,7 @@ object RecordErrorCode {
       values.find(x => x.code == xml.text) match {
         case Some(errorCode) => ParseSuccess(errorCode)
         case None =>
-          try ParseSuccess(UnknownRecordErrorCode(Integer.parseInt(xml.text).toString))
+          try ParseSuccess(UnknownRecordErrorCode(xml.text))
           catch {
             case _: Exception => ParseFailure(RecordErrorCodeParseError(s"Invalid or missing RecordErrorCode: ${xml.text}"))
           }

--- a/conf/xsd/DCT52b_EIS_Response.xsd
+++ b/conf/xsd/DCT52b_EIS_Response.xsd
@@ -59,10 +59,16 @@
 	</xs:complexType>
 	<xs:complexType name="FileError_Type">
 		<xs:sequence>
-			<xs:element name="Code" type="gsm:StringMin1Max4000_Type">
+			<xs:element name="Code">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">Error Code</xs:documentation>
 				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:minLength value="1"/>
+						<xs:maxLength value="18"/>
+					</xs:restriction>
+				</xs:simpleType>
 			</xs:element>
 			<xs:element name="Details" type="gsm:ErrorDetail_Type" minOccurs="0">
 				<xs:annotation>
@@ -73,10 +79,16 @@
 	</xs:complexType>
 	<xs:complexType name="RecordError_Type">
 		<xs:sequence>
-			<xs:element name="Code" type="gsm:StringMin1Max4000_Type">
+			<xs:element name="Code">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">Error Code</xs:documentation>
 				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:minLength value="1"/>
+						<xs:maxLength value="18"/>
+					</xs:restriction>
+				</xs:simpleType>
 			</xs:element>
 			<xs:element name="Details" type="gsm:ErrorDetail_Type" minOccurs="0">
 				<xs:annotation>

--- a/conf/xsd/DCT52b_EIS_Response.xsd
+++ b/conf/xsd/DCT52b_EIS_Response.xsd
@@ -59,7 +59,7 @@
 	</xs:complexType>
 	<xs:complexType name="FileError_Type">
 		<xs:sequence>
-			<xs:element name="Code" type="gsm:StringMin1Max10_Type">
+			<xs:element name="Code" type="gsm:StringMin1Max4000_Type">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">Error Code</xs:documentation>
 				</xs:annotation>
@@ -73,7 +73,7 @@
 	</xs:complexType>
 	<xs:complexType name="RecordError_Type">
 		<xs:sequence>
-			<xs:element name="Code" type="gsm:StringMin1Max10_Type">
+			<xs:element name="Code" type="gsm:StringMin1Max4000_Type">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">Error Code</xs:documentation>
 				</xs:annotation>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.18.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.19.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.2.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.18")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.0.6")

--- a/test/models/xml/FileErrorCodeSpec.scala
+++ b/test/models/xml/FileErrorCodeSpec.scala
@@ -36,9 +36,9 @@ class FileErrorCodeSpec extends SpecBase with ScalaCheckPropertyChecks {
       FileErrorCode.xmlReads.read(xml) mustBe ParseSuccess(UnknownFileErrorCode("50000"))
     }
 
-    "return ParseFailureError for invalid value" in {
-      val xml = <Code>Invalid</Code>
-      FileErrorCode.xmlReads.read(xml) mustBe an[ParseFailure]
+    "read CBC Error Codes" in {
+      val xml = <Code>CBC Error Code 39a</Code>
+      FileErrorCode.xmlReads.read(xml) mustBe ParseSuccess(UnknownFileErrorCode("CBC Error Code 39a"))
     }
   }
 }

--- a/test/models/xml/FileErrorsSpec.scala
+++ b/test/models/xml/FileErrorsSpec.scala
@@ -44,14 +44,5 @@ class FileErrorsSpec extends SpecBase {
 
       XmlReader.of[FileErrors].read(xml) mustBe ParseSuccess(FileErrors(UnknownFileErrorCode("50011"), Some("error message")))
     }
-
-    "must fail to read xml as FileErrors for invalid code" in {
-      val xml: Elem = <gsm:FileError>
-        <gsm:Code>invalid</gsm:Code>
-        <gsm:Details Language="EN">error message</gsm:Details>
-      </gsm:FileError>
-
-      XmlReader.of[FileErrors].read(xml) mustBe an[ParseFailure]
-    }
   }
 }

--- a/test/models/xml/RecordErrorCodeSpec.scala
+++ b/test/models/xml/RecordErrorCodeSpec.scala
@@ -35,9 +35,9 @@ class RecordErrorCodeSpec extends SpecBase {
       RecordErrorCode.xmlReads.read(xml) mustBe ParseSuccess(UnknownRecordErrorCode("50000"))
     }
 
-    "return ParseFailureError for invalid value" in {
-      val xml = <Code>Invalid</Code>
-      RecordErrorCode.xmlReads.read(xml) mustBe an[ParseFailure]
+    "read CBC Error Codes" in {
+      val xml = <Code>CBC Error Code 39a</Code>
+      RecordErrorCode.xmlReads.read(xml) mustBe ParseSuccess(UnknownRecordErrorCode("CBC Error Code 39a"))
     }
   }
 }

--- a/test/models/xml/RecordErrorSpec.scala
+++ b/test/models/xml/RecordErrorSpec.scala
@@ -47,14 +47,5 @@ class RecordErrorSpec extends SpecBase {
 
       XmlReader.of[RecordError].read(xml) mustBe ParseSuccess(RecordError(UnknownRecordErrorCode("50011"), Some("error message"), None))
     }
-
-    "must fail to read xml as FileErrors for invalid code" in {
-      val xml: Elem = <gsm:FileError>
-        <gsm:Code>invalid</gsm:Code>
-        <gsm:Details Language="EN">error message</gsm:Details>
-      </gsm:FileError>
-
-      XmlReader.of[RecordError].read(xml) mustBe an[ParseFailure]
-    }
   }
 }


### PR DESCRIPTION
In order to allow the new CBC error codes e.g. "CBC Error Code 39a" we have to:

* Allow error codes to contain text (remove parseInt)
* Amend the XSD schema to allow for more than 10 characters

We will need to request a new schema from EIS and update that in due course - for now we just need to be aware we have made manual changes and raise a JIRA ticket to come back to this.