### PR TITLE
DAC6-3355: Update report type logic for CBC401 messages

### DIFF
--- a/app/services/DataExtraction.scala
+++ b/app/services/DataExtraction.scala
@@ -41,7 +41,11 @@ class DataExtraction()() {
     if (allDocTypeIndicators.exists(indic => testDataIndicators.contains(indic))) {
       TestData
     } else if (messageTypeIndicator == CBC401) {
-      NewInformation
+      if (reportingEntityDocTypeIndicators.contains("OECD1")) {
+        NewInformation
+      } else {
+        NewInformationForExistingReport
+      }
     } else if (reportingEntityDocTypeIndicators.contains("OECD3")) {
       DeletionOfAllInformation
     } else if (cbcReportAndAdditionalInfoSections.nonEmpty) {
@@ -49,7 +53,6 @@ class DataExtraction()() {
       val uniqueDocTypes             = docTypeIndicators.map(node => node.text).distinct
 
       (uniqueDocTypes.length, uniqueDocTypes.headOption) match {
-        case (1, Some("OECD1"))                                                       => NewInformationForExistingReport
         case (1, Some("OECD2"))                                                       => CorrectionForExistingReport
         case (1, Some("OECD3")) if reportingEntityDocTypeIndicators.contains("OECD0") => DeletionForExistingReport
         case _                                                                        => CorrectionAndDeletionForExistingReport

--- a/test/services/DataExtractionSpec.scala
+++ b/test/services/DataExtractionSpec.scala
@@ -97,7 +97,7 @@ class DataExtractionSpec extends SpecBase {
   "messageSpecData" - {
 
     "must return Some(MessageSpecData) when given valid xml" in {
-      val xml = generateValidXml()
+      val xml = generateValidXml(reportingEntityDocTypeIndic = List(Some("OECD1")))
 
       dataExtraction.messageSpecData(xml) mustBe Some(MessageSpecData("MessageRefId", CBC401, "Name", NewInformation))
     }
@@ -152,10 +152,16 @@ class DataExtractionSpec extends SpecBase {
       }
     }
 
-    "must return NewInformationReportType if the MessageTypeIndic is CBC401" in {
-      val xml = generateValidXml()
+    "must return NewInformationReportType if the MessageTypeIndic is CBC401 and any ReportingEntity DocTypeIndic is OECD1" in {
+      val xml = generateValidXml(reportingEntityDocTypeIndic = List(Some("OECD1")))
 
       dataExtraction.getReportType(CBC401, xml) mustBe NewInformation
+    }
+
+    "must return NewInformationForExistingReport if the MessageTypeIndic is CBC401 and none of ReportingEntity DocTypeIndic is OECD1" in {
+      val xml = generateValidXml(reportingEntityDocTypeIndic = List(Some("OECD2")))
+
+      dataExtraction.getReportType(CBC401, xml) mustBe NewInformationForExistingReport
     }
 
     "must return DeletionOfAllPreviousInformationReportType if any ReportingEntity DocTypeIndic is OECD3" in {
@@ -180,15 +186,6 @@ class DataExtractionSpec extends SpecBase {
       )
 
       dataExtraction.getReportType(CBC402, xml) mustBe CorrectionAndDeletionForExistingReport
-    }
-
-    "must return NewInformationForExistingReport if all the DocTypeIndic values in CbcReports or AdditionalInfo are OECD1" in {
-      val xml = generateValidXml(
-        cbcReportDocTypeIndic = List(Some("OECD1"), None),
-        additionalInfoDocTypeIndic = List(Some("OECD1"))
-      )
-
-      dataExtraction.getReportType(CBC402, xml) mustBe NewInformationForExistingReport
     }
 
     "must return CorrectionsForExistingReportType if all the DocTypeIndic values in CbcReports or AdditionalInfo are OECD2" in {


### PR DESCRIPTION
Refactor `getReportType` to distinguish between `NewInformation` and `NewInformationForExistingReport` for CBC401 messages based on the presence of the "OECD1" indicator. Adjusted corresponding test cases to validate the new logic.