### PR TITLE
DAC6-3429: Add userType to audit logs

### DIFF
--- a/app/models/audit/AuditType.scala
+++ b/app/models/audit/AuditType.scala
@@ -16,7 +16,21 @@
 
 package models.audit
 
+import play.api.libs.json.{Json, OWrites}
+import uk.gov.hmrc.auth.core.AffinityGroup
+
 object AuditType {
   val eisResponse    = "CountryByCountryReportingEISResponse"
   val fileSubmission = "CountryByCountryReportingSDESResponse"
+}
+
+final case class AuditWithUserType[T](details: T, userType: Option[AffinityGroup] = None)
+
+object AuditWithUserType {
+
+  implicit def writes[T: OWrites]: OWrites[AuditWithUserType[T]] = (auditWithUserType: AuditWithUserType[T]) => {
+    val detailsJson  = Json.toJsObject(auditWithUserType.details)
+    val userTypeJson = auditWithUserType.userType.map(userType => Json.obj("userType" -> userType)).getOrElse(Json.obj())
+    detailsJson ++ userTypeJson
+  }
 }

--- a/app/models/submission/FileDetails.scala
+++ b/app/models/submission/FileDetails.scala
@@ -18,6 +18,7 @@ package models.submission
 
 import models.agentSubscription.AgentContactDetails
 import play.api.libs.json._
+import uk.gov.hmrc.auth.core.AffinityGroup
 
 import java.time.{Instant, LocalDateTime, ZoneOffset}
 import javax.inject.Singleton
@@ -32,7 +33,8 @@ case class FileDetails(_id: ConversationId,
                        name: String,
                        submitted: LocalDateTime,
                        lastUpdated: LocalDateTime,
-                       agentDetails: Option[AgentContactDetails] = None
+                       agentDetails: Option[AgentContactDetails] = None,
+                       userType: Option[AffinityGroup] = None
 )
 object FileDetails {
   final val localDateTimeReads: Reads[LocalDateTime] =

--- a/it/test/repositories/submission/FileDetailsRepositorySpec.scala
+++ b/it/test/repositories/submission/FileDetailsRepositorySpec.scala
@@ -23,6 +23,7 @@ import models.submission._
 import models.subscription.{ContactInformation, OrganisationDetails}
 import models.xml.{FileErrorCode, FileErrors, ValidationErrors}
 import services.metrics.MetricsService
+import uk.gov.hmrc.auth.core.AffinityGroup
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 
 import java.time.LocalDateTime
@@ -48,7 +49,8 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
       Pending,
       "file1.xml",
       dateTimeNow,
-      dateTimeNow
+      dateTimeNow,
+      userType = Some(AffinityGroup.Organisation)
     )
 
   val agentPrimaryContact: ContactInformation = ContactInformation(
@@ -77,7 +79,8 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
     "file1.xml",
     dateTimeNow,
     dateTimeNow,
-    Some(agentDetails)
+    Some(agentDetails),
+    Some(AffinityGroup.Agent)
   )
 
   "Insert" - {
@@ -167,6 +170,7 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
                             "file1.xml",
                             _,
                             _,
+                            _,
                             _
                 )
               ) =>
@@ -192,7 +196,8 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
                             "file1.xml",
                             _,
                             _,
-                            _
+                            _,
+                            Some(AffinityGroup.Agent)
                 )
               ) =>
         }
@@ -220,7 +225,8 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
                             "file1.xml",
                             _,
                             _,
-                            None
+                            None,
+                            Some(AffinityGroup.Organisation)
                 )
               ) =>
         }

--- a/test/controllers/EISResponseControllerSpec.scala
+++ b/test/controllers/EISResponseControllerSpec.scala
@@ -102,6 +102,7 @@ class EISResponseControllerSpec extends SpecBase with BeforeAndAfterEach {
           LocalDateTime.now()
         )
 
+      when(mockFileDetailsRepository.findByConversationId(any[ConversationId])).thenReturn(Future.successful(Some(fileDetails)))
       when(mockFileDetailsRepository.updateStatus(any[String], any[FileStatus])).thenReturn(Future.successful(Some(fileDetails)))
       when(
         mockEmailService.sendAndLogEmail(any[String], any[String], any[String], any[Option[AgentContactDetails]], any[Boolean], any[ReportType])(
@@ -152,6 +153,7 @@ class EISResponseControllerSpec extends SpecBase with BeforeAndAfterEach {
           LocalDateTime.now(),
           LocalDateTime.now()
         )
+      when(mockFileDetailsRepository.findByConversationId(any[ConversationId])).thenReturn(Future.successful(Some(fileDetails)))
       when(mockAuditService.sendAuditEvent(any[String], any[JsValue])(any[HeaderCarrier], any[ExecutionContext])).thenReturn(Future.successful(Success))
       when(mockFileDetailsRepository.updateStatus(any[String], any[FileStatus])).thenReturn(Future.successful(Some(fileDetails)))
       when(
@@ -191,6 +193,7 @@ class EISResponseControllerSpec extends SpecBase with BeforeAndAfterEach {
           LocalDateTime.now(),
           LocalDateTime.now()
         )
+      when(mockFileDetailsRepository.findByConversationId(any[ConversationId])).thenReturn(Future.successful(Some(fileDetails)))
       when(mockAuditService.sendAuditEvent(any[String], any[JsValue])(any[HeaderCarrier], any[ExecutionContext])).thenReturn(Future.successful(Success))
       when(mockFileDetailsRepository.updateStatus(any[String], any[FileStatus])).thenReturn(Future.successful(Some(fileDetails)))
       when(
@@ -230,6 +233,7 @@ class EISResponseControllerSpec extends SpecBase with BeforeAndAfterEach {
           LocalDateTime.now().minusSeconds(11),
           LocalDateTime.now()
         )
+      when(mockFileDetailsRepository.findByConversationId(any[ConversationId])).thenReturn(Future.successful(Some(fileDetails)))
       when(mockAuditService.sendAuditEvent(any[String], any[JsValue])(any[HeaderCarrier], any[ExecutionContext])).thenReturn(Future.successful(Success))
       when(mockFileDetailsRepository.updateStatus(any[String], any[FileStatus])).thenReturn(Future.successful(Some(fileDetails)))
       when(
@@ -269,6 +273,7 @@ class EISResponseControllerSpec extends SpecBase with BeforeAndAfterEach {
           LocalDateTime.now().minusSeconds(11),
           LocalDateTime.now()
         )
+      when(mockFileDetailsRepository.findByConversationId(any[ConversationId])).thenReturn(Future.successful(Some(fileDetails)))
       when(mockAuditService.sendAuditEvent(any[String], any[JsValue])(any[HeaderCarrier], any[ExecutionContext])).thenReturn(Future.successful(Success))
       when(mockFileDetailsRepository.updateStatus(any[String], any[FileStatus])).thenReturn(Future.successful(Some(fileDetails)))
       when(
@@ -310,6 +315,7 @@ class EISResponseControllerSpec extends SpecBase with BeforeAndAfterEach {
     }
 
     "must return InternalServerError on failing to update the status" in {
+      when(mockFileDetailsRepository.findByConversationId(any[ConversationId])).thenReturn(Future.failed(new RuntimeException("Failed to get file details")))
       when(mockAuditService.sendAuditEvent(any(), any())(any(), any())).thenReturn(Future.successful(Success))
       when(mockFileDetailsRepository.updateStatus(any[String](), any[FileStatus]())).thenReturn(Future.successful(None))
 

--- a/test/controllers/sdes/SdesCallbackControllerSpec.scala
+++ b/test/controllers/sdes/SdesCallbackControllerSpec.scala
@@ -35,6 +35,7 @@ import services.EmailService
 import services.audit.AuditService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpVerbs.POST
+import uk.gov.hmrc.play.audit.http.connector.AuditResult.Success
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -62,6 +63,7 @@ class SdesCallbackControllerSpec extends SpecBase with BeforeAndAfterEach with S
 
       forAll(arbitrarySuccessSdesCallback.arbitrary, arbitrary[FileDetails]) { (sdesCallback, fileDetails) =>
         reset(mockAuditService)
+        when(mockAuditService.sendAuditEvent(any(), any())(any(), any())).thenReturn(Future.successful(Success))
         when(mockFileDetailsRepository.findByConversationId(sdesCallback.correlationID)).thenReturn(Future.successful(Some(fileDetails)))
 
         val request = FakeRequest(POST, routes.SdesCallbackController.callback.url).withBody(Json.toJson(sdesCallback))
@@ -75,6 +77,7 @@ class SdesCallbackControllerSpec extends SpecBase with BeforeAndAfterEach with S
     "must return Ok for failure notification and update status and send email" in {
       forAll(arbitraryFailureSdesCallback.arbitrary, arbitraryPendingFileDetails.arbitrary) { (sdesCallback, fileDetails) =>
         reset(mockAuditService)
+        when(mockAuditService.sendAuditEvent(any(), any())(any(), any())).thenReturn(Future.successful(Success))
         val updatedStatus = sdesCallback.failureReason match {
           case Some(reason) if reason.toLowerCase.contains("virus") => RejectedSDESVirus
           case _                                                    => RejectedSDES
@@ -109,6 +112,7 @@ class SdesCallbackControllerSpec extends SpecBase with BeforeAndAfterEach with S
     "must return Ok for failure notification but do not update status and neither send email if file status not pending" in {
       forAll(arbitraryFailureSdesCallback.arbitrary, arbitraryNonPendingFileDetails.arbitrary) { (sdesCallback, fileDetails) =>
         reset(mockAuditService)
+        when(mockAuditService.sendAuditEvent(any(), any())(any(), any())).thenReturn(Future.successful(Success))
         when(mockFileDetailsRepository.findByConversationId(sdesCallback.correlationID)).thenReturn(Future.successful(Some(fileDetails)))
 
         val request = FakeRequest(POST, routes.SdesCallbackController.callback.url).withBody(Json.toJson(sdesCallback))

--- a/test/models/audit/AuditWithUserTypeSpec.scala
+++ b/test/models/audit/AuditWithUserTypeSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.audit
+
+import base.SpecBase
+import models.sdes.{NotificationType, SHA256, SdesCallback}
+import models.submission.ConversationId
+import play.api.libs.json.{JsObject, Json}
+import uk.gov.hmrc.auth.core.AffinityGroup
+
+class AuditWithUserTypeSpec extends SpecBase {
+
+  private val auditWithUserType = AuditWithUserType(
+    details = SdesCallback(
+      notification = NotificationType.FileReady,
+      filename = "filename",
+      checksumAlgorithm = SHA256,
+      checksum = "checksum",
+      correlationID = ConversationId("correlationID"),
+      dateTime = None,
+      failureReason = None
+    ),
+    userType = Some(AffinityGroup.Organisation)
+  )
+
+  private val json =
+    """
+      |{
+      |"notification": "FileReady",
+      |"filename": "filename",
+      |"checksumAlgorithm": "SHA-256",
+      |"checksum": "checksum",
+      |"correlationID": "correlationID",
+      |"userType": "Organisation"
+      |}
+      |""".stripMargin
+
+  "AuditWithUserType" - {
+    "marshal" in {
+      val jsonObj = AuditWithUserType.writes[SdesCallback].writes(auditWithUserType)
+      jsonObj mustBe Json.parse(json).as[JsObject]
+    }
+  }
+}


### PR DESCRIPTION
Enhanced the audit logging functionality by including the userType attribute in the audit events. This change allows tracking of the user's affinity group for improved auditing and data analysis. Updated relevant tests and repository logic to support this new attribute seamlessly.