### PR TITLE
DAC6-3429: Add audit logging for file submissions

### DIFF
--- a/app/controllers/sdes/SdesCallbackController.scala
+++ b/app/controllers/sdes/SdesCallbackController.scala
@@ -16,7 +16,7 @@
 
 package controllers.sdes
 
-import models.audit.AuditType.fileSubmission
+import models.audit.AuditType.sdesResponse
 import models.audit.AuditWithUserType
 import models.sdes.NotificationType.FileProcessingFailure
 import models.sdes.SdesCallback
@@ -53,12 +53,12 @@ class SdesCallbackController @Inject() (
         .flatMap {
           case Some(fileDetails) =>
             val audit = AuditWithUserType(sdesCallback, fileDetails.userType)
-            auditService.sendAuditEvent(fileSubmission, Json.toJson(audit))
-          case _ => auditService.sendAuditEvent(fileSubmission, Json.toJson(sdesCallback))
+            auditService.sendAuditEvent(sdesResponse, Json.toJson(audit))
+          case _ => auditService.sendAuditEvent(sdesResponse, Json.toJson(sdesCallback))
         }
         .recoverWith { case e: Exception =>
           logger.error(s"Failed to get fileDetails: ${e.getMessage}")
-          auditService.sendAuditEvent(fileSubmission, Json.toJson(sdesCallback))
+          auditService.sendAuditEvent(sdesResponse, Json.toJson(sdesCallback))
         }
       sdesCallback match {
         case SdesCallback(FileProcessingFailure, _, _, _, correlationID, _, failureReason) =>

--- a/app/models/audit/AuditType.scala
+++ b/app/models/audit/AuditType.scala
@@ -21,7 +21,8 @@ import uk.gov.hmrc.auth.core.AffinityGroup
 
 object AuditType {
   val eisResponse    = "CountryByCountryReportingEISResponse"
-  val fileSubmission = "CountryByCountryReportingSDESResponse"
+  val sdesResponse   = "CountryByCountryReportingSDESResponse"
+  val fileSubmission = "CountryByCountryReportingFileSubmission"
 }
 
 final case class AuditWithUserType[T](details: T, userType: Option[AffinityGroup] = None)

--- a/app/models/submission/FileDetails.scala
+++ b/app/models/submission/FileDetails.scala
@@ -34,7 +34,8 @@ case class FileDetails(_id: ConversationId,
                        submitted: LocalDateTime,
                        lastUpdated: LocalDateTime,
                        agentDetails: Option[AgentContactDetails] = None,
-                       userType: Option[AffinityGroup] = None
+                       userType: Option[AffinityGroup] = None,
+                       fileType: Option[FileType] = None
 )
 object FileDetails {
   final val localDateTimeReads: Reads[LocalDateTime] =

--- a/app/models/submission/FileType.scala
+++ b/app/models/submission/FileType.scala
@@ -14,21 +14,25 @@
  * limitations under the License.
  */
 
-package models.error
+package models.submission
 
 import julienrf.json.derived
 import play.api.libs.json.OFormat
 
-trait BackendError {
-  def detail: String
-}
+sealed trait FileType
 
-final case class SdesSubmissionError(status: Int) extends BackendError {
-  override def detail: String = s"SDES submission failed with status $status"
-}
-final case class RepositoryError(detail: String) extends BackendError
-final case class SubmissionServiceError(detail: String) extends BackendError
+case object NormalFile extends FileType
+case object LargeFile extends FileType
 
-object SubmissionServiceError {
-  implicit val format: OFormat[SubmissionServiceError] = derived.oformat()
+object FileType {
+
+  val values: Seq[FileType] = Seq(NormalFile, LargeFile)
+
+  def fromString(fileType: String): FileType = fileType.toUpperCase match {
+    case "NORMAL" => NormalFile
+    case "LARGE"  => LargeFile
+    case _        => throw new NoSuchElementException
+  }
+
+  implicit val format: OFormat[FileType] = derived.oformat[FileType]()
 }

--- a/it/test/repositories/submission/FileDetailsRepositorySpec.scala
+++ b/it/test/repositories/submission/FileDetailsRepositorySpec.scala
@@ -171,6 +171,7 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
                             _,
                             _,
                             _,
+                            _,
                             _
                 )
               ) =>
@@ -197,7 +198,8 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
                             _,
                             _,
                             _,
-                            Some(AffinityGroup.Agent)
+                            Some(AffinityGroup.Agent),
+                            _
                 )
               ) =>
         }
@@ -226,7 +228,8 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
                             _,
                             _,
                             None,
-                            Some(AffinityGroup.Organisation)
+                            Some(AffinityGroup.Organisation),
+                            _
                 )
               ) =>
         }


### PR DESCRIPTION
Enhanced the submission service by integrating audit logging for file submissions. Updated various components to include file type in `FileDetails` and ensured appropriate logging for normal and large file submissions as well as submission errors.