### PR TITLE
DAC6-3504: Refactor audit models and error handling

### DIFF
--- a/app/controllers/validation/SubmissionValidationController.scala
+++ b/app/controllers/validation/SubmissionValidationController.scala
@@ -44,18 +44,18 @@ class SubmissionValidationController @Inject() (
       case JsSuccess(upscanURL, _) =>
         validationEngine.validateUploadSubmission(upscanURL.url) map {
           case SubmissionValidationSuccess(msd) =>
-            auditService.sendAuditEvent(AuditType.fileSubmission, Json.toJson(msd))
+            auditService.sendAuditEvent(AuditType.fileValidation, Json.toJson(msd))
             Ok(Json.toJsObject(SubmissionValidationSuccess(msd)))
 
           case SubmissionValidationFailure(errors) =>
             val audit = Audit(SubmissionValidationFailure(errors), userType = Some(request.affinityGroup), error = Some("Failed to validate xml submission"))
-            auditService.sendAuditEvent(AuditType.fileSubmissionError, Json.toJson(audit))
+            auditService.sendAuditEvent(AuditType.fileValidationError, Json.toJson(audit))
             logger.warn("Failed to validate xml submission")
             Ok(Json.toJson(SubmissionValidationFailure(errors)))
 
           case InvalidXmlError(saxException) =>
             val audit = Audit(InvalidXmlError(saxException), userType = Some(request.affinityGroup), error = Some("Invalid XML"))
-            auditService.sendAuditEvent(AuditType.fileSubmissionError, Json.toJson(audit))
+            auditService.sendAuditEvent(AuditType.fileValidationError, Json.toJson(audit))
             logger.warn("InvalidXmlError: Failed to validate xml submission")
             BadRequest(InvalidXmlError(saxException).toString)
 
@@ -65,14 +65,14 @@ class SubmissionValidationController @Inject() (
               userType = Some(request.affinityGroup),
               error = Some("Failed to validate xml submission")
             )
-            auditService.sendAuditEvent(AuditType.fileSubmissionError, Json.toJson(audit))
+            auditService.sendAuditEvent(AuditType.fileValidationError, Json.toJson(audit))
             logger.warn("Failed to validate xml submission")
             InternalServerError("failed to validateSubmission")
         }
       case JsError(errors) =>
         logger.warn(s"Missing upscan URL: $errors")
         val audit = Audit(InvalidXmlError(s"Missing upscan URL: $errors"), userType = Some(request.affinityGroup), error = Some("Missing upscan URL"))
-        auditService.sendAuditEvent(AuditType.fileSubmissionError, Json.toJson(audit))
+        auditService.sendAuditEvent(AuditType.fileValidationError, Json.toJson(audit))
         logger.warn("Missing upscan URL")
         Future.successful(InternalServerError("Missing upscan URL"))
     }

--- a/app/controllers/validation/SubmissionValidationController.scala
+++ b/app/controllers/validation/SubmissionValidationController.scala
@@ -17,7 +17,7 @@
 package controllers.validation
 
 import controllers.auth.IdentifierAuthAction
-import models.audit.{AuditType, AuditWithUserType}
+import models.audit.{Audit, AuditType}
 import models.upscan.UpscanURL
 import models.validation.{InvalidXmlError, SubmissionValidationFailure, SubmissionValidationSuccess}
 import play.api.Logging
@@ -44,29 +44,36 @@ class SubmissionValidationController @Inject() (
       case JsSuccess(upscanURL, _) =>
         validationEngine.validateUploadSubmission(upscanURL.url) map {
           case SubmissionValidationSuccess(msd) =>
+            auditService.sendAuditEvent(AuditType.fileSubmission, Json.toJson(msd))
             Ok(Json.toJsObject(SubmissionValidationSuccess(msd)))
 
           case SubmissionValidationFailure(errors) =>
-            val audit = AuditWithUserType(SubmissionValidationFailure(errors), Some(request.affinityGroup))
-            auditService.sendAuditEvent(AuditType.fileSubmission, Json.toJson(audit))
+            val audit = Audit(SubmissionValidationFailure(errors), userType = Some(request.affinityGroup), error = Some("Failed to validate xml submission"))
+            auditService.sendAuditEvent(AuditType.fileSubmissionError, Json.toJson(audit))
+            logger.warn("Failed to validate xml submission")
             Ok(Json.toJson(SubmissionValidationFailure(errors)))
 
           case InvalidXmlError(saxException) =>
-            val audit = AuditWithUserType(InvalidXmlError(saxException), Some(request.affinityGroup))
-            auditService.sendAuditEvent(AuditType.fileSubmission, Json.toJson(audit))
+            val audit = Audit(InvalidXmlError(saxException), userType = Some(request.affinityGroup), error = Some("Invalid XML"))
+            auditService.sendAuditEvent(AuditType.fileSubmissionError, Json.toJson(audit))
             logger.warn("InvalidXmlError: Failed to validate xml submission")
             BadRequest(InvalidXmlError(saxException).toString)
 
           case _ =>
-            val audit = AuditWithUserType(InvalidXmlError("Failed to validate xml submission"), Some(request.affinityGroup))
-            auditService.sendAuditEvent(AuditType.fileSubmission, Json.toJson(audit))
+            val audit = Audit(
+              InvalidXmlError("Failed to validate xml submission"),
+              userType = Some(request.affinityGroup),
+              error = Some("Failed to validate xml submission")
+            )
+            auditService.sendAuditEvent(AuditType.fileSubmissionError, Json.toJson(audit))
             logger.warn("Failed to validate xml submission")
             InternalServerError("failed to validateSubmission")
         }
       case JsError(errors) =>
         logger.warn(s"Missing upscan URL: $errors")
-        val audit = AuditWithUserType(InvalidXmlError(s"Missing upscan URL: $errors"), Some(request.affinityGroup))
-        auditService.sendAuditEvent(AuditType.fileSubmission, Json.toJson(audit))
+        val audit = Audit(InvalidXmlError(s"Missing upscan URL: $errors"), userType = Some(request.affinityGroup), error = Some("Missing upscan URL"))
+        auditService.sendAuditEvent(AuditType.fileSubmissionError, Json.toJson(audit))
+        logger.warn("Missing upscan URL")
         Future.successful(InternalServerError("Missing upscan URL"))
     }
   }

--- a/app/models/audit/AuditType.scala
+++ b/app/models/audit/AuditType.scala
@@ -26,6 +26,8 @@ object AuditType {
   val sdesResponseError   = "CountryByCountryReportingSDESResponseError"
   val fileSubmission      = "CountryByCountryReportingFileSubmission"
   val fileSubmissionError = "CountryByCountryReportingFileSubmissionError"
+  val fileValidation      = "CountryByCountryReportingFileValidation"
+  val fileValidationError = "CountryByCountryReportingFileValidationError"
 }
 
 final case class Audit[T](details: T, userType: Option[AffinityGroup] = None, correlationId: Option[String] = None, error: Option[String] = None)

--- a/app/models/audit/AuditType.scala
+++ b/app/models/audit/AuditType.scala
@@ -20,18 +20,23 @@ import play.api.libs.json.{Json, OWrites}
 import uk.gov.hmrc.auth.core.AffinityGroup
 
 object AuditType {
-  val eisResponse    = "CountryByCountryReportingEISResponse"
-  val sdesResponse   = "CountryByCountryReportingSDESResponse"
-  val fileSubmission = "CountryByCountryReportingFileSubmission"
+  val eisResponse         = "CountryByCountryReportingEISResponse"
+  val eisResponseError    = "CountryByCountryReportingEISResponseError"
+  val sdesResponse        = "CountryByCountryReportingSDESResponse"
+  val sdesResponseError   = "CountryByCountryReportingSDESResponseError"
+  val fileSubmission      = "CountryByCountryReportingFileSubmission"
+  val fileSubmissionError = "CountryByCountryReportingFileSubmissionError"
 }
 
-final case class AuditWithUserType[T](details: T, userType: Option[AffinityGroup] = None)
+final case class Audit[T](details: T, userType: Option[AffinityGroup] = None, correlationId: Option[String] = None, error: Option[String] = None)
 
-object AuditWithUserType {
+object Audit {
 
-  implicit def writes[T: OWrites]: OWrites[AuditWithUserType[T]] = (auditWithUserType: AuditWithUserType[T]) => {
-    val detailsJson  = Json.toJsObject(auditWithUserType.details)
-    val userTypeJson = auditWithUserType.userType.map(userType => Json.obj("userType" -> userType)).getOrElse(Json.obj())
-    detailsJson ++ userTypeJson
+  implicit def writes[T: OWrites]: OWrites[Audit[T]] = (audit: Audit[T]) => {
+    val detailsJson       = Json.toJsObject(audit.details)
+    val userTypeJson      = audit.userType.map(userType => Json.obj("userType" -> userType)).getOrElse(Json.obj())
+    val correlationIdJson = audit.correlationId.map(correlationId => Json.obj("correlationId" -> correlationId)).getOrElse(Json.obj())
+    val errorJson         = audit.error.map(error => Json.obj("error" -> error)).getOrElse(Json.obj())
+    detailsJson ++ userTypeJson ++ correlationIdJson ++ errorJson
   }
 }

--- a/test/controllers/sdes/SdesCallbackControllerSpec.scala
+++ b/test/controllers/sdes/SdesCallbackControllerSpec.scala
@@ -69,7 +69,7 @@ class SdesCallbackControllerSpec extends SpecBase with BeforeAndAfterEach with S
         val request = FakeRequest(POST, routes.SdesCallbackController.callback.url).withBody(Json.toJson(sdesCallback))
         val result  = route(application, request).value
         status(result) mustEqual OK
-        verify(mockAuditService, times(1)).sendAuditEvent(any[String](), any[JsValue]())(any[HeaderCarrier], any[ExecutionContext])
+        verify(mockAuditService, times(2)).sendAuditEvent(any[String](), any[JsValue]())(any[HeaderCarrier], any[ExecutionContext])
 
       }
     }
@@ -94,7 +94,7 @@ class SdesCallbackControllerSpec extends SpecBase with BeforeAndAfterEach with S
         val result  = route(application, request).value
 
         status(result) mustEqual OK
-        verify(mockAuditService, times(1)).sendAuditEvent(any[String](), any[JsValue]())(any[HeaderCarrier], any[ExecutionContext])
+        verify(mockAuditService, times(2)).sendAuditEvent(any[String](), any[JsValue]())(any[HeaderCarrier], any[ExecutionContext])
         verify(mockFileDetailsRepository).updateStatus(sdesCallback.correlationID.value, updatedStatus)
         verify(mockEmailService, atLeast(1)).sendAndLogEmail(is(fileDetails.subscriptionId),
                                                              any[String],
@@ -119,7 +119,7 @@ class SdesCallbackControllerSpec extends SpecBase with BeforeAndAfterEach with S
         val result  = route(application, request).value
 
         status(result) mustEqual OK
-        verify(mockAuditService, times(1)).sendAuditEvent(any[String](), any[JsValue]())(any[HeaderCarrier], any[ExecutionContext])
+        verify(mockAuditService, times(2)).sendAuditEvent(any[String](), any[JsValue]())(any[HeaderCarrier], any[ExecutionContext])
         verify(mockFileDetailsRepository, times(0)).updateStatus(any[String], any[FileStatus])
         verify(mockEmailService, times(0)).sendAndLogEmail(any[String],
                                                            any[String],

--- a/test/models/audit/AuditSpec.scala
+++ b/test/models/audit/AuditSpec.scala
@@ -22,9 +22,9 @@ import models.submission.ConversationId
 import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.auth.core.AffinityGroup
 
-class AuditWithUserTypeSpec extends SpecBase {
+class AuditSpec extends SpecBase {
 
-  private val auditWithUserType = AuditWithUserType(
+  private val audit = Audit(
     details = SdesCallback(
       notification = NotificationType.FileReady,
       filename = "filename",
@@ -34,7 +34,8 @@ class AuditWithUserTypeSpec extends SpecBase {
       dateTime = None,
       failureReason = None
     ),
-    userType = Some(AffinityGroup.Organisation)
+    userType = Some(AffinityGroup.Organisation),
+    error = Some("error")
   )
 
   private val json =
@@ -45,13 +46,14 @@ class AuditWithUserTypeSpec extends SpecBase {
       |"checksumAlgorithm": "SHA-256",
       |"checksum": "checksum",
       |"correlationID": "correlationID",
-      |"userType": "Organisation"
+      |"userType": "Organisation",
+      |"error": "error"
       |}
       |""".stripMargin
 
   "AuditWithUserType" - {
     "marshal" in {
-      val jsonObj = AuditWithUserType.writes[SdesCallback].writes(auditWithUserType)
+      val jsonObj = Audit.writes[SdesCallback].writes(audit)
       jsonObj mustBe Json.parse(json).as[JsObject]
     }
   }


### PR DESCRIPTION
Replaced `AuditWithUserType` with a more flexible `Audit` model, adding support for error details and correlation IDs. Enhanced audit logging across controllers to provide clearer error context, introducing specific error events for failures.