### PR TITLE
DAC6-3504: Update audit event type for error scenarios

### DIFF
--- a/app/services/submission/SubmissionService.scala
+++ b/app/services/submission/SubmissionService.scala
@@ -112,13 +112,13 @@ class SubmissionService @Inject() (
             } yield conversationId
           case None =>
             val error = SubmissionServiceError(s"Xml file with conversation Id [${conversationId.value}] is empty", Some(request.affinityGroup))
-            auditService.sendAuditEvent(AuditType.fileSubmission, Json.toJson(error))
+            auditService.sendAuditEvent(AuditType.fileSubmissionError, Json.toJson(error))
             EitherT.left(Future.successful(error))
         }
       case Failure(_) =>
         val error =
           SubmissionServiceError(s"Failed to load xml file [$documentUrl] with conversation Id [${conversationId.value}]", Some(request.affinityGroup))
-        auditService.sendAuditEvent(AuditType.fileSubmission, Json.toJson(error))
+        auditService.sendAuditEvent(AuditType.fileSubmissionError, Json.toJson(error))
         EitherT.left(Future.successful(error))
     }
 


### PR DESCRIPTION
Replaced `fileSubmission` with `fileSubmissionError` to ensure proper distinction between successful submissions and error reporting during XML file handling. This improves audit event clarity and debugging efficiency.