### PR TITLE
DAC6-3644: Add audit logging for UpScan callbacks

### DIFF
--- a/app/models/upscan/UpscanResponse.scala
+++ b/app/models/upscan/UpscanResponse.scala
@@ -124,3 +124,16 @@ case class FailedCallbackBody(
   reference: Reference,
   failureDetails: ErrorDetails
 ) extends CallbackBody
+
+object FailedCallbackBody {
+  implicit val writes: OWrites[FailedCallbackBody] = OWrites { failedCallbackBody =>
+    Json.obj(
+      "reference" -> Json.toJsFieldJsValueWrapper(
+        failedCallbackBody.reference
+      ),
+      "failureDetails" -> Json.toJsFieldJsValueWrapper(
+        failedCallbackBody.failureDetails
+      )
+    )
+  }
+}

--- a/test/controllers/upscan/UploadCallbackController.scala
+++ b/test/controllers/upscan/UploadCallbackController.scala
@@ -19,20 +19,20 @@ package controllers.upscan
 import models.upscan.CallbackBody
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.JsValue
-import play.api.mvc.{Action, BaseController, MessagesControllerComponents}
+import play.api.mvc.{Action, ControllerComponents}
 import services.upscan.UpScanCallbackDispatcher
-
-import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.play.bootstrap.controller.WithJsonBody
 
-@Singleton
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
 class UploadCallbackController @Inject() (
-  val controllerComponents: MessagesControllerComponents,
+  val cc: ControllerComponents,
   val upscanCallbackDispatcher: UpScanCallbackDispatcher,
   implicit override val messagesApi: MessagesApi
 )(implicit val ec: ExecutionContext)
-    extends BaseController
+    extends BackendController(cc)
     with WithJsonBody
     with I18nSupport {
 

--- a/test/services/upscan/UpScanCallbackDispatcherSpec.scala
+++ b/test/services/upscan/UpScanCallbackDispatcherSpec.scala
@@ -17,22 +17,26 @@
 package services.upscan
 
 import base.SpecBase
-import models.upscan.{ErrorDetails, FailedCallbackBody, Quarantined, ReadyCallbackBody, Reference, UploadDetails, UploadRejected, UploadedSuccessfully}
+import models.upscan._
 import play.api.Application
 import play.api.inject.bind
-import models.upscan.Failed
+import services.audit.AuditService
+
 import java.time.Instant
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class UpScanCallbackDispatcherSpec extends SpecBase {
 
   val mockUploadProgressTracker: UploadProgressTracker =
     mock[UploadProgressTracker]
+  val mockAuditService: AuditService = mock[AuditService]
 
   val application: Application =
     applicationBuilder()
       .overrides(
-        bind[UploadProgressTracker].toInstance(mockUploadProgressTracker)
+        bind[UploadProgressTracker].toInstance(mockUploadProgressTracker),
+        bind[AuditService].toInstance(mockAuditService)
       )
       .build()
 
@@ -73,7 +77,7 @@ class UpScanCallbackDispatcherSpec extends SpecBase {
       ).thenReturn(Future.successful(true))
 
       val uploadCallbackDispatcher =
-        new UpScanCallbackDispatcher(mockUploadProgressTracker)
+        new UpScanCallbackDispatcher(mockUploadProgressTracker, mockAuditService)
 
       val result: Future[Boolean] =
         uploadCallbackDispatcher.handleCallback(readyCallbackBody)
@@ -92,9 +96,10 @@ class UpScanCallbackDispatcherSpec extends SpecBase {
       when(
         mockUploadProgressTracker.registerUploadResult(reference, uploadStatus)
       ).thenReturn(Future.successful(true))
+//      when(mockAuditService.sendAuditEvent(any(), any())).thenReturn(Future.successful(Success))
 
       val uploadCallbackDispatcher =
-        new UpScanCallbackDispatcher(mockUploadProgressTracker)
+        new UpScanCallbackDispatcher(mockUploadProgressTracker, mockAuditService)
 
       val result: Future[Boolean] =
         uploadCallbackDispatcher.handleCallback(readyCallbackBody)
@@ -115,7 +120,7 @@ class UpScanCallbackDispatcherSpec extends SpecBase {
       ).thenReturn(Future.successful(true))
 
       val uploadCallbackDispatcher =
-        new UpScanCallbackDispatcher(mockUploadProgressTracker)
+        new UpScanCallbackDispatcher(mockUploadProgressTracker, mockAuditService)
 
       val result: Future[Boolean] =
         uploadCallbackDispatcher.handleCallback(readyCallbackBody)
@@ -136,7 +141,7 @@ class UpScanCallbackDispatcherSpec extends SpecBase {
       ).thenReturn(Future.successful(true))
 
       val uploadCallbackDispatcher =
-        new UpScanCallbackDispatcher(mockUploadProgressTracker)
+        new UpScanCallbackDispatcher(mockUploadProgressTracker, mockAuditService)
 
       val result: Future[Boolean] =
         uploadCallbackDispatcher.handleCallback(readyCallbackBody)

--- a/test/services/upscan/UpScanCallbackDispatcherSpec.scala
+++ b/test/services/upscan/UpScanCallbackDispatcherSpec.scala
@@ -18,9 +18,11 @@ package services.upscan
 
 import base.SpecBase
 import models.upscan._
+import org.mockito.ArgumentMatchers.any
 import play.api.Application
 import play.api.inject.bind
 import services.audit.AuditService
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
 
 import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -75,6 +77,7 @@ class UpScanCallbackDispatcherSpec extends SpecBase {
       when(
         mockUploadProgressTracker.registerUploadResult(reference, uploadStatus)
       ).thenReturn(Future.successful(true))
+      when(mockAuditService.sendAuditEvent(any(), any())(any(), any())).thenReturn(Future.successful(AuditResult.Success))
 
       val uploadCallbackDispatcher =
         new UpScanCallbackDispatcher(mockUploadProgressTracker, mockAuditService)
@@ -96,7 +99,7 @@ class UpScanCallbackDispatcherSpec extends SpecBase {
       when(
         mockUploadProgressTracker.registerUploadResult(reference, uploadStatus)
       ).thenReturn(Future.successful(true))
-//      when(mockAuditService.sendAuditEvent(any(), any())).thenReturn(Future.successful(Success))
+      when(mockAuditService.sendAuditEvent(any(), any())(any(), any())).thenReturn(Future.successful(AuditResult.Success))
 
       val uploadCallbackDispatcher =
         new UpScanCallbackDispatcher(mockUploadProgressTracker, mockAuditService)
@@ -118,6 +121,7 @@ class UpScanCallbackDispatcherSpec extends SpecBase {
       when(
         mockUploadProgressTracker.registerUploadResult(reference, uploadStatus)
       ).thenReturn(Future.successful(true))
+      when(mockAuditService.sendAuditEvent(any(), any())(any(), any())).thenReturn(Future.successful(AuditResult.Success))
 
       val uploadCallbackDispatcher =
         new UpScanCallbackDispatcher(mockUploadProgressTracker, mockAuditService)
@@ -139,6 +143,7 @@ class UpScanCallbackDispatcherSpec extends SpecBase {
       when(
         mockUploadProgressTracker.registerUploadResult(reference, uploadStatus)
       ).thenReturn(Future.successful(true))
+      when(mockAuditService.sendAuditEvent(any(), any())(any(), any())).thenReturn(Future.successful(AuditResult.Success))
 
       val uploadCallbackDispatcher =
         new UpScanCallbackDispatcher(mockUploadProgressTracker, mockAuditService)


### PR DESCRIPTION
Integrate `AuditService` into `UpScanCallbackDispatcher` and `UploadCallbackController` to log callback events. Enhance error handling in `UploadCallbackController` by auditing invalid callback payloads and returning `BadRequest`.