### PR TITLE
DAC6-3648: Migrate to HttpClientV2

### DIFF
--- a/app/connectors/AgentSubscriptionConnector.scala
+++ b/app/connectors/AgentSubscriptionConnector.scala
@@ -19,57 +19,45 @@ package connectors
 import com.google.inject.Inject
 import config.AppConfig
 import models.agentSubscription.AgentSubscriptionEtmpRequest
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class AgentSubscriptionConnector @Inject() (
   val config: AppConfig,
-  val http: HttpClient
+  val http: HttpClientV2
 ) {
 
   def createSubscription(agentSubscription: AgentSubscriptionEtmpRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
     val serviceName = "create-agent-subscription"
 
-    http.POST[AgentSubscriptionEtmpRequest, HttpResponse](
-      config.serviceUrl(serviceName),
-      agentSubscription,
-      headers = extraHeaders(serviceName)
-    )(
-      wts = AgentSubscriptionEtmpRequest.format,
-      rds = httpReads,
-      hc = hc,
-      ec = ec
-    )
+    http
+      .post(url"${config.serviceUrl(serviceName)}")
+      .setHeader(extraHeaders(serviceName): _*)
+      .withBody(Json.toJson(agentSubscription))
+      .execute[HttpResponse]
   }
 
   def readSubscription(agentRefNo: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
     val serviceName = "read-agent-subscription"
 
-    http.GET[HttpResponse](
-      s"${config.serviceUrl(serviceName)}/ARN/$agentRefNo",
-      headers = extraHeaders(serviceName)
-    )(
-      rds = httpReads,
-      hc = hc,
-      ec = ec
-    )
+    http
+      .get(url"${config.serviceUrl(serviceName)}/ARN/$agentRefNo")
+      .setHeader(extraHeaders(serviceName): _*)
+      .execute[HttpResponse]
   }
 
   def updateSubscription(agentSubscription: AgentSubscriptionEtmpRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
 
     val serviceName = "update-agent-subscription"
 
-    http.PUT[AgentSubscriptionEtmpRequest, HttpResponse](
-      config.serviceUrl(serviceName),
-      agentSubscription,
-      extraHeaders(serviceName)
-    )(
-      wts = AgentSubscriptionEtmpRequest.format,
-      rds = httpReads,
-      hc = hc,
-      ec = ec
-    )
+    http
+      .put(url"${config.serviceUrl(serviceName)}")
+      .setHeader(extraHeaders(serviceName): _*)
+      .withBody(Json.toJson(agentSubscription))
+      .execute[HttpResponse]
   }
 
   private def extraHeaders(serviceName: String)(implicit hc: HeaderCarrier): Seq[(String, String)] = Seq()

--- a/app/connectors/EmailConnector.scala
+++ b/app/connectors/EmailConnector.scala
@@ -18,15 +18,20 @@ package connectors
 
 import config.AppConfig
 import models.email.EmailRequest
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class EmailConnector @Inject() (val config: AppConfig, http: HttpClient)(implicit ex: ExecutionContext) {
+class EmailConnector @Inject() (val config: AppConfig, http: HttpClientV2)(implicit ex: ExecutionContext) {
 
   def sendEmail(emailRequest: EmailRequest)(implicit hc: HeaderCarrier): Future[HttpResponse] =
-    http.POST[EmailRequest, HttpResponse](s"${config.sendEmailUrl}/hmrc/email", emailRequest)
+    http
+      .post(url"${config.sendEmailUrl}/hmrc/email")
+      .withBody(Json.toJson(emailRequest))
+      .execute[HttpResponse]
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -20,7 +20,6 @@ include "backend.conf"
 appName = country-by-country-reporting
 
 # Default http client
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"


### PR DESCRIPTION
Replaced the deprecated HttpClient with HttpClientV2 across all connectors for improved functionality and consistency. Updated method calls to use the new fluent API, ensuring compatibility with existing configurations.