### PR TITLE
DAC6-3267 - CBC: Small/large file - set alert for file submission, slow/no response from other DG's

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -22,6 +22,8 @@ import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
+import scala.concurrent.duration.FiniteDuration
+
 @Singleton
 class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig) {
 
@@ -63,4 +65,8 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
   lazy val sdesUrl: String = List(Option(servicesConfig.baseUrl("sdes")), sdesLocation, Some("notification"), Some("fileready")).flatten.mkString("/")
 
   lazy val sdesChecksumAlgorithm: Algorithm = Algorithm(config.get[String]("sdes.checksum-algorithm"))
+
+  val staleTaskEnabled: Boolean           = config.get[Boolean]("tasks.staleFiles.enabled")
+  val staleTaskInterval: FiniteDuration   = config.get[FiniteDuration]("tasks.staleFiles.interval")
+  val staleTaskAlertAfter: FiniteDuration = config.get[FiniteDuration]("tasks.staleFiles.alertAfter")
 }

--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -18,6 +18,7 @@ package config
 
 import com.google.inject.AbstractModule
 import services.upscan.{MongoBackedUploadProgressTracker, UploadProgressTracker}
+import tasks.StaleFileTask
 
 import java.time.{Clock, ZoneOffset}
 
@@ -26,5 +27,6 @@ class Module() extends AbstractModule {
   override def configure(): Unit = {
     bind(classOf[UploadProgressTracker]).to(classOf[MongoBackedUploadProgressTracker])
     bind(classOf[Clock]).toInstance(Clock.systemDefaultZone.withZone(ZoneOffset.UTC))
+    bind(classOf[StaleFileTask]).asEagerSingleton()
   }
 }

--- a/app/models/submission/FileDetails.scala
+++ b/app/models/submission/FileDetails.scala
@@ -56,4 +56,14 @@ object FileDetails {
       case other         => other
     }
   implicit val format: Format[FileDetails] = Format(reads, writes)
+
+  def logMessageForStaleReport(fileDetails: FileDetails): String = {
+    val sentTo = fileDetails.fileType match {
+      case Some(LargeFile)  => "SDES"
+      case Some(NormalFile) => "EIS"
+      case _                => "EIS"
+    }
+    s"Stale file found - Report Type: ${fileDetails.reportType}, ConversationId: ${fileDetails._id.value}, Filename: ${fileDetails.name}, File Type: ${fileDetails.fileType
+      .getOrElse("")}, Sent to $sentTo"
+  }
 }

--- a/app/repositories/submission/FileDetailsRepository.scala
+++ b/app/repositories/submission/FileDetailsRepository.scala
@@ -111,4 +111,10 @@ class FileDetailsRepository @Inject() (
         true
       }
 
+  def findStaleSubmissions(): Future[Seq[FileDetails]] = {
+    Future {
+      Seq()
+    }
+  }
+
 }

--- a/app/repositories/submission/FileDetailsRepository.scala
+++ b/app/repositories/submission/FileDetailsRepository.scala
@@ -54,7 +54,7 @@ class FileDetailsRepository @Inject() (
                      .name("subscriptionId-index")
                      .unique(false)
         ),
-        IndexModel(ascending("status"), // Todo is there any config I need to add in some other project for this?
+        IndexModel(ascending("status"),
                    IndexOptions()
                      .name("status-index")
                      .unique(false)

--- a/app/repositories/submission/FileDetailsRepository.scala
+++ b/app/repositories/submission/FileDetailsRepository.scala
@@ -55,9 +55,9 @@ class FileDetailsRepository @Inject() (
                      .unique(false)
         ),
         IndexModel(ascending("status"), // Todo is there any config I need to add in some other project for this?
-          IndexOptions()
-            .name("status-index")
-            .unique(false)
+                   IndexOptions()
+                     .name("status-index")
+                     .unique(false)
         )
       ),
       replaceIndexes = true

--- a/app/tasks/StaleFileTask.scala
+++ b/app/tasks/StaleFileTask.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import org.apache.pekko.actor.ActorSystem
+import config.AppConfig
+import play.api.Logging
+import play.api.inject.ApplicationLifecycle
+import repositories.submission.FileDetailsRepository
+import uk.gov.hmrc.mongo.TimestampSupport
+import uk.gov.hmrc.mongo.lock.{MongoLockRepository, ScheduledLockService}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+@Singleton
+class StaleFileTask @Inject() (actorSystem: ActorSystem,
+                               repository: FileDetailsRepository,
+                               lifecycle: ApplicationLifecycle,
+                               config: AppConfig,
+                               mongoLockRepository: MongoLockRepository,
+                               timestampSupport: TimestampSupport
+)(implicit
+  executionContext: ExecutionContext
+) extends Logging {
+
+  private val enabled  = config.staleTaskEnabled
+  private val interval = config.staleTaskInterval
+
+  if (enabled) {
+
+    val lockService = ScheduledLockService(
+      lockRepository = mongoLockRepository,
+      lockId = "stale-file-task",
+      timestampSupport = timestampSupport,
+      schedulerInterval = interval
+    )
+
+    val cancellable = actorSystem.scheduler.scheduleWithFixedDelay(initialDelay = 1.second, interval) { () =>
+      lockService
+        .withLock {
+          logger.info("StaleFileTask: Started")
+
+          repository
+            .findStaleSubmissions()
+            .map { files =>
+              files.foreach(file => logger.warn(s"StaleFileTask: Stale file found. ConversationId: ${file._id.value}, Filename: ${file.name}"))
+              files.length
+            }
+        }
+        .onComplete {
+          case Success(result) =>
+            result match {
+              case Some(staleRecordCount) => logger.info(s"StaleFileTask: Complete. $staleRecordCount stale files found.")
+              case None                   => ()
+            }
+          case Failure(e) => logger.warn(s"StaleFileTask: An error occurred: ${e.getMessage}", e)
+        }
+    }
+
+    lifecycle.addStopHook(() => Future.successful(cancellable.cancel()))
+
+  }
+
+}

--- a/app/tasks/StaleFileTask.scala
+++ b/app/tasks/StaleFileTask.scala
@@ -16,8 +16,9 @@
 
 package tasks
 
-import org.apache.pekko.actor.ActorSystem
 import config.AppConfig
+import models.submission.FileDetails.logMessageForStaleReport
+import org.apache.pekko.actor.ActorSystem
 import play.api.Logging
 import play.api.inject.ApplicationLifecycle
 import repositories.submission.FileDetailsRepository
@@ -60,7 +61,7 @@ class StaleFileTask @Inject() (actorSystem: ActorSystem,
           repository
             .findStaleSubmissions()
             .map { files =>
-              files.foreach(file => logger.warn(s"StaleFileTask: Stale file found. ConversationId: ${file._id.value}, Filename: ${file.name}"))
+              files.foreach(file => logger.warn(logMessageForStaleReport(file)))
               files.length
             }
         }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -195,3 +195,11 @@ sdes {
   recipient-or-sender = "cbc-reporting"
   checksum-algorithm = "SHA-256"
 }
+
+tasks {
+    staleFiles {
+        enabled = true
+        interval = 10 minutes
+        alertAfter = 2 hours
+    }
+}

--- a/it/test/repositories/submission/FileDetailsRepositorySpec.scala
+++ b/it/test/repositories/submission/FileDetailsRepositorySpec.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import java.time.LocalDateTime
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
 
 class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepositorySupport[FileDetails] {
 
@@ -36,6 +37,7 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
 
   private val mockAppConfig = mock[AppConfig]
   when(mockAppConfig.cacheTtl) thenReturn 1
+  when(mockAppConfig.staleTaskAlertAfter) thenReturn 2.hours
 
   override lazy val repository = new FileDetailsRepository(mongoComponent, mockAppConfig, metricsService)
 
@@ -252,12 +254,21 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
 
   "findStaleSubmissions" - {
     "should retrieve a stale pending submission " in {
+      val oldPendingFile = fileDetails.copy(submitted = dateTimeNow.minusDays(1), name = "oldfile.xml", _id = ConversationId("conversationId777777"))
+      val oldRejectedFile = fileDetails.copy(status = RejectedSDES,
+        submitted = dateTimeNow.minusDays(1),
+        name = "oldishfile.xml",
+        _id = ConversationId("conversationId777778"))
+
       val result: Future[Seq[FileDetails]] = for {
+        _   <- repository.insert(fileDetails)
+        _   <- repository.insert(oldPendingFile)
+        _   <- repository.insert(oldRejectedFile)
         res <- repository.findStaleSubmissions()
       } yield res
 
       whenReady(result) {
-        _ mustBe List()
+        _ mustBe List(oldPendingFile)
       }
     }
   }

--- a/it/test/repositories/submission/FileDetailsRepositorySpec.scala
+++ b/it/test/repositories/submission/FileDetailsRepositorySpec.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 
 import java.time.LocalDateTime
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepositorySupport[FileDetails] {
 
@@ -247,6 +248,18 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
       }
     }
 
+  }
+
+  "findStaleSubmissions" - {
+    "should retrieve a stale pending submission " in {
+      val result: Future[Seq[FileDetails]] = for {
+        res <- repository.findStaleSubmissions()
+      } yield res
+
+      whenReady(result) {
+        _ mustBe List()
+      }
+    }
   }
 
 }

--- a/test/models/submission/FileDetailsSpec.scala
+++ b/test/models/submission/FileDetailsSpec.scala
@@ -46,5 +46,30 @@ class FileDetailsSpec extends AnyFreeSpec with Matchers {
       (json \ "conversationId").as[String] shouldBe "conversationId"
     }
 
+    "should contain relevant information to be logged when record is stale" in {
+      val fileDetails = FileDetails(
+        _id = ConversationId("conversationId"),
+        subscriptionId = "submissionId",
+        messageRefId = "messageRefId",
+        reportingEntityName = "reportingEntityName",
+        reportType = TestData,
+        status = Accepted,
+        name = "report.xml",
+        submitted = LocalDateTime.now(),
+        lastUpdated = LocalDateTime.now(),
+        agentDetails = None,
+        userType = None,
+        fileType = Some(LargeFile)
+      )
+
+      val expectedMessageLargeFile =
+        s"Stale file found - Report Type: TestData, ConversationId: conversationId, Filename: report.xml, File Type: LargeFile, Sent to SDES"
+      val expectedMessageNormalFile =
+        s"Stale file found - Report Type: TestData, ConversationId: conversationId, Filename: report.xml, File Type: NormalFile, Sent to EIS"
+
+      FileDetails.logMessageForStaleReport(fileDetails) shouldBe expectedMessageLargeFile
+      FileDetails.logMessageForStaleReport(fileDetails.copy(fileType = Some(NormalFile))) shouldBe expectedMessageNormalFile
+    }
+
   }
 }

--- a/test/tasks/StaleFileTaskSpec.scala
+++ b/test/tasks/StaleFileTaskSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tasks
+
+import base.SpecBase
+import config.AppConfig
+import org.apache.pekko.actor.{ActorSystem, Cancellable, Scheduler}
+import org.mockito.ArgumentMatchers.{any, argThat}
+import org.mockito._
+import play.api.Configuration
+import play.api.inject.ApplicationLifecycle
+import repositories.submission.FileDetailsRepository
+import uk.gov.hmrc.mongo.TimestampSupport
+import uk.gov.hmrc.mongo.lock.MongoLockRepository
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+class StaleFileTaskSpec extends SpecBase {
+
+  lazy val config = app.injector.instanceOf[Configuration]
+
+  private val mockAppConfig             = mock[AppConfig]
+  private val mockFileDetailsRepository = mock[FileDetailsRepository]
+  private val mockMongoLockRepository   = mock[MongoLockRepository]
+  private val mockTimestampSupport      = mock[TimestampSupport]
+  private val mockActorSystem           = mock[ActorSystem]
+  private val mockScheduler             = mock[Scheduler]
+  private val mockCancellable           = mock[Cancellable]
+  private val applicatinLifecycle       = app.injector.instanceOf[ApplicationLifecycle]
+  val runnableCaptor                    = ArgumentCaptor.forClass(classOf[Runnable])
+  val initialDelayCaptor                = ArgumentCaptor.forClass(classOf[FiniteDuration])
+  val intervalCaptor                    = ArgumentCaptor.forClass(classOf[FiniteDuration])
+  when(mockAppConfig.staleTaskInterval) thenReturn 2.hours
+
+  "StaleFileTask" - {
+    "should not be scheduled when staleTaskEnabled feature flag is false" in {
+      when(mockAppConfig.staleTaskEnabled) thenReturn false
+
+      val staleFileTask = new StaleFileTask(
+        mockActorSystem,
+        mockFileDetailsRepository,
+        applicatinLifecycle,
+        mockAppConfig,
+        mockMongoLockRepository,
+        mockTimestampSupport
+      )
+
+      verify(mockActorSystem, never).scheduler
+    }
+
+    "should be scheduled when staleTaskEnabled feature flag is true" in {
+      when(mockAppConfig.staleTaskEnabled) thenReturn true
+      when(mockActorSystem.scheduler).thenReturn(mockScheduler)
+
+      when(
+        mockScheduler.scheduleWithFixedDelay(
+          any[FiniteDuration],
+          any[FiniteDuration]
+        )(any[Runnable])(any[ExecutionContext])
+      ).thenReturn(mockCancellable)
+
+      val staleFileTask = new StaleFileTask(
+        mockActorSystem,
+        mockFileDetailsRepository,
+        applicatinLifecycle,
+        mockAppConfig,
+        mockMongoLockRepository,
+        mockTimestampSupport
+      )
+
+      verify(mockScheduler, times(1)).scheduleWithFixedDelay(
+        argThat((delay: FiniteDuration) => delay == 1.second),
+        argThat((interval: FiniteDuration) => interval == 2.hours)
+      )(
+        argThat((runnable: Runnable) => runnable != null)
+      )(
+        argThat((ec: ExecutionContext) => ec != null)
+      )
+    }
+  }
+
+}

--- a/test/tasks/StaleFileTaskSpec.scala
+++ b/test/tasks/StaleFileTaskSpec.scala
@@ -43,9 +43,6 @@ class StaleFileTaskSpec extends SpecBase {
   private val mockScheduler             = mock[Scheduler]
   private val mockCancellable           = mock[Cancellable]
   private val applicatinLifecycle       = app.injector.instanceOf[ApplicationLifecycle]
-  val runnableCaptor                    = ArgumentCaptor.forClass(classOf[Runnable])
-  val initialDelayCaptor                = ArgumentCaptor.forClass(classOf[FiniteDuration])
-  val intervalCaptor                    = ArgumentCaptor.forClass(classOf[FiniteDuration])
   when(mockAppConfig.staleTaskInterval) thenReturn 2.hours
 
   "StaleFileTask" - {


### PR DESCRIPTION
Ticket: https://jira.tools.tax.service.gov.uk/browse/DAC6-3267
Changes:
1. Added  FileDetailsRepository#findStaleSubmissions to retrieve stale submissions
2. Added StaleFilteTask to call above service and log stale submissions details
3. Added FileDetails#logMessageForStaleReport to create a message that will be logged
4. Added config to schedule when StaleFilteTask will run
5. Test for StaleFilteTask, FileDetailsRepository and FileDetails