### PR TITLE
DAC6-3775 | address duplicate normal submission event

### DIFF
--- a/app/services/submission/SubmissionService.scala
+++ b/app/services/submission/SubmissionService.scala
@@ -76,6 +76,13 @@ class SubmissionService @Inject() (
                                              request.affinityGroup,
                                              Some(LargeFile)
       )
+      _ = sendAuditEvent(
+        submissionDetails = submissionDetails,
+        fileReferenceId = fileReferenceId,
+        fileStatus = fileDetails.status,
+        userType = fileDetails.userType,
+        submissionTime = fileDetails.submitted
+      )
       _ <- EitherT(persistFileDetails(fileDetails, submissionDetails))
     } yield conversationId).value
   }
@@ -105,7 +112,13 @@ class SubmissionService @Inject() (
                                                      request.affinityGroup,
                                                      Some(NormalFile)
               )
-              _ = auditService.sendAuditEvent(AuditType.fileSubmission, Json.toJson(fileDetails))
+              _ = sendAuditEvent(
+                submissionDetails = submissionDetails,
+                fileReferenceId = fileReferenceId,
+                fileStatus = fileDetails.status,
+                userType = fileDetails.userType,
+                submissionTime = fileDetails.submitted
+              )
               _ <- EitherT(addSubscriptionDetailsToXml(xml, submissionMetaData, orgContactDetails, fileDetails))
               _ <- EitherT(persistFileDetails(fileDetails, submissionDetails))
             } yield conversationId
@@ -215,13 +228,6 @@ class SubmissionService @Inject() (
     fileDetailsRepository
       .insert(fileDetails)
       .map {
-        sendAuditEvent(
-          submissionDetails = submissionDetails,
-          fileReferenceId = fileReferenceId,
-          fileStatus = fileDetails.status,
-          userType = fileDetails.userType,
-          submissionTime = fileDetails.submitted
-        )
         Right(_)
       }
       .recover { _ =>

--- a/app/services/submission/SubmissionService.scala
+++ b/app/services/submission/SubmissionService.scala
@@ -232,14 +232,7 @@ class SubmissionService @Inject() (
       }
       .recover { _ =>
         val errorMessage = s"Failed to persist details for file with conversation Id [${fileDetails._id.value}]"
-        sendAuditEvent(
-          submissionDetails = submissionDetails,
-          fileReferenceId = fileReferenceId,
-          fileStatus = fileDetails.status,
-          submissionTime = fileDetails.submitted,
-          userType = fileDetails.userType,
-          error = Some(errorMessage)
-        )
+        logger.error(s"ERROR: $errorMessage")
         Left(RepositoryError(errorMessage))
       }
 

--- a/test/services/submission/SubmissionServiceSpec.scala
+++ b/test/services/submission/SubmissionServiceSpec.scala
@@ -121,7 +121,8 @@ class SubmissionServiceSpec extends SpecBase with IntegrationPatience with Gener
 
           result.futureValue.value mustBe conversationId
           assertOnFileDetails(agentRefNo, submissionDetails, agentDetails, conversationId)
-          verify(mockAuditService, atLeastOnce).sendAuditEvent(mEq(AuditType.fileSubmission), any[JsValue])(any(), any())
+          verify(mockAuditService, times(1)).sendAuditEvent(mEq(AuditType.fileSubmission), any[JsValue])(any(), any())
+          reset(mockAuditService)
         }
       }
 
@@ -185,7 +186,8 @@ class SubmissionServiceSpec extends SpecBase with IntegrationPatience with Gener
           val result = submissionService.submitLargeFile(submissionDetails)
 
           result.futureValue.left.value mustBe a[RepositoryError]
-          verify(mockAuditService, atLeastOnce).sendAuditEvent(mEq(AuditType.fileSubmission), any[JsValue])(any(), any())
+          verify(mockAuditService, times(2)).sendAuditEvent(mEq(AuditType.fileSubmission), any[JsValue])(any(), any())
+          reset(mockAuditService)
         }
       }
     }
@@ -220,7 +222,8 @@ class SubmissionServiceSpec extends SpecBase with IntegrationPatience with Gener
 
           result.futureValue.value mustBe conversationId
           assertOnFileDetails(agentRefNo, submissionDetails, agentDetails, conversationId)
-          verify(mockAuditService, atLeastOnce).sendAuditEvent(mEq(AuditType.fileSubmission), any[JsValue])(any(), any())
+          verify(mockAuditService, times(1)).sendAuditEvent(mEq(AuditType.fileSubmission), any[JsValue])(any(), any())
+          reset(mockAuditService)
         }
       }
 
@@ -254,7 +257,8 @@ class SubmissionServiceSpec extends SpecBase with IntegrationPatience with Gener
             val result = submissionService.submitNormalFile(submissionDetails)
 
             result.futureValue.left.value mustBe a[SubmissionServiceError]
-            verify(mockAuditService, atLeastOnce).sendAuditEvent(mEq(AuditType.fileSubmission), any[JsValue])(any(), any())
+            verify(mockAuditService, times(1)).sendAuditEvent(mEq(AuditType.fileSubmission), any[JsValue])(any(), any())
+            reset(mockAuditService)
         }
       }
 

--- a/test/services/submission/SubmissionServiceSpec.scala
+++ b/test/services/submission/SubmissionServiceSpec.scala
@@ -186,7 +186,7 @@ class SubmissionServiceSpec extends SpecBase with IntegrationPatience with Gener
           val result = submissionService.submitLargeFile(submissionDetails)
 
           result.futureValue.left.value mustBe a[RepositoryError]
-          verify(mockAuditService, times(2)).sendAuditEvent(mEq(AuditType.fileSubmission), any[JsValue])(any(), any())
+          verify(mockAuditService, times(1)).sendAuditEvent(mEq(AuditType.fileSubmission), any[JsValue])(any(), any())
           reset(mockAuditService)
         }
       }


### PR DESCRIPTION
move around events to avoid duplicates; unless persistence fails. upgrade spec to check for expected number of audit events.