### PR TITLE
NOJIRA: Refactor error models

### DIFF
--- a/app/controllers/SubscriptionController.scala
+++ b/app/controllers/SubscriptionController.scala
@@ -42,6 +42,7 @@ class SubscriptionController @Inject() (
       case Left(ReadSubscriptionError(value)) =>
         logger.warn(s"ReadSubscriptionError $value")
         InternalServerError(s"ReadSubscriptionError $value")
+      case _ => InternalServerError("Unexpected error")
     }
   }
 
@@ -61,6 +62,7 @@ class SubscriptionController @Inject() (
           case Left(UpdateSubscriptionError(value)) =>
             logger.warn(s"UpdateSubscriptionError $value")
             InternalServerError(s"UpdateSubscriptionError $value")
+          case _ => InternalServerError("Unexpected error")
         }
     )
 

--- a/app/models/error/ApiError.scala
+++ b/app/models/error/ApiError.scala
@@ -16,14 +16,8 @@
 
 package models.error
 
-sealed trait ApiError extends BackendError {
-  override def detail: String
-}
+abstract class ApiError private[error] (detail: String) extends BackendError(detail)
 
-case class UpdateSubscriptionError(status: Int) extends ApiError {
-  override def detail: String = s"Failed to update subscription. Got status $status"
-}
+case class UpdateSubscriptionError(status: Int) extends ApiError(detail = s"Failed to update subscription. Got status $status")
 
-case class ReadSubscriptionError(status: Int) extends ApiError {
-  override def detail: String = s"Failed to read subscription. Got status $status"
-}
+case class ReadSubscriptionError(status: Int) extends ApiError(detail = s"Failed to read subscription. Got status $status")

--- a/app/models/error/BackendError.scala
+++ b/app/models/error/BackendError.scala
@@ -20,15 +20,11 @@ import julienrf.json.derived
 import play.api.libs.json.OFormat
 import uk.gov.hmrc.auth.core.AffinityGroup
 
-trait BackendError {
-  def detail: String
-}
+abstract class BackendError private[error] (val detail: String)
 
-final case class SdesSubmissionError(status: Int) extends BackendError {
-  override def detail: String = s"SDES submission failed with status $status"
-}
-final case class RepositoryError(detail: String) extends BackendError
-final case class SubmissionServiceError(detail: String, userType: Option[AffinityGroup] = None) extends BackendError
+final case class SdesSubmissionError(status: Int) extends BackendError(detail = s"SDES submission failed with status $status")
+final case class RepositoryError(override val detail: String) extends BackendError(detail = detail)
+final case class SubmissionServiceError(override val detail: String, userType: Option[AffinityGroup] = None) extends BackendError(detail = detail)
 
 object SubmissionServiceError {
   implicit val format: OFormat[SubmissionServiceError] = derived.oformat()

--- a/app/models/error/DownStreamError.scala
+++ b/app/models/error/DownStreamError.scala
@@ -20,9 +20,7 @@ import play.api.libs.json.{Json, OFormat}
 
 import java.time.LocalDateTime
 
-sealed trait DownStreamError extends BackendError {
-  override def detail: String
-}
+class DownStreamError private[error] (detail: String) extends BackendError(detail)
 
 final case class BusinessErrorDetail(processingDate: LocalDateTime, code: String, text: String)
 
@@ -30,9 +28,7 @@ object BusinessErrorDetail {
   implicit val format: OFormat[BusinessErrorDetail] = Json.format[BusinessErrorDetail]
 }
 
-final case class BusinessValidationError(errors: BusinessErrorDetail) extends DownStreamError {
-  override def detail: String = s"code: ${errors.code}, message: ${errors.text}"
-}
+final case class BusinessValidationError(errors: BusinessErrorDetail) extends DownStreamError(detail = s"code: ${errors.code}, message: ${errors.text}")
 
 object BusinessValidationError {
   implicit val format: OFormat[BusinessValidationError] = Json.format[BusinessValidationError]
@@ -44,9 +40,8 @@ object BackendSAPSystemErrorDetail {
   implicit val format: OFormat[BackendSAPSystemErrorDetail] = Json.format[BackendSAPSystemErrorDetail]
 }
 
-final case class BackendSAPSystemError(error: BackendSAPSystemErrorDetail) extends DownStreamError {
-  override def detail: String = s"code: ${error.code}, message: ${error.message}, logId: ${error.logID}"
-}
+final case class BackendSAPSystemError(error: BackendSAPSystemErrorDetail)
+    extends DownStreamError(detail = s"code: ${error.code}, message: ${error.message}, logId: ${error.logID}")
 
 object BackendSAPSystemError {
   implicit val format: OFormat[BackendSAPSystemError] = Json.format[BackendSAPSystemError]
@@ -71,9 +66,7 @@ object ErrorDetail {
   implicit val format: OFormat[ErrorDetail] = Json.format[ErrorDetail]
 }
 
-final case class ErrorDetails(errorDetail: ErrorDetail) extends DownStreamError {
-  override def detail: String = s"${errorDetail.sourceFaultDetail.map(_.detail.mkString)}"
-}
+final case class ErrorDetails(errorDetail: ErrorDetail) extends DownStreamError(detail = s"${errorDetail.sourceFaultDetail.map(_.detail.mkString)}")
 
 object ErrorDetails {
   implicit val format: OFormat[ErrorDetails] = Json.format[ErrorDetails]

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -145,6 +145,8 @@ class EmailService @Inject() (emailConnector: EmailConnector, emailTemplate: Ema
       case Left(ReadSubscriptionError(value)) =>
         logger.warn(s"Failed to get contact information, received ReadSubscriptionError: $value")
         Future.successful(Seq(EmailResult("Failed to get contact information", None)))
+      case _ =>
+        Future.successful(Seq(EmailResult("Unexpected Error", None)))
     }
 
   private def send(emailAddress: Option[String],

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -19,7 +19,7 @@ package services
 import connectors.SubscriptionConnector
 import models.audit.AuditType.updateContactDetails
 import models.audit.{Audit, AuditDetailForUpdateOrgSubscriptionRequest}
-import models.error.{BackendError, ReadSubscriptionError, UpdateSubscriptionError}
+import models.error.{ApiError, ReadSubscriptionError, UpdateSubscriptionError}
 import models.subscription._
 import play.api.Logging
 import play.api.http.Status.OK
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class SubscriptionService @Inject() (subscriptionConnector: SubscriptionConnector, auditService: AuditService) extends Logging {
 
-  def getContactInformation(enrolmentId: String)(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[Either[BackendError, ResponseDetail]] = {
+  def getContactInformation(enrolmentId: String)(implicit hc: HeaderCarrier, ex: ExecutionContext): Future[Either[ApiError, ResponseDetail]] = {
 
     val subscriptionRequest: DisplaySubscriptionForCBCRequest =
       DisplaySubscriptionForCBCRequest(

--- a/app/services/submission/SubmissionService.scala
+++ b/app/services/submission/SubmissionService.scala
@@ -84,7 +84,7 @@ class SubmissionService @Inject() (
         userType = fileDetails.userType,
         submissionTime = fileDetails.submitted
       )
-      _ <- EitherT(persistFileDetails(fileDetails, submissionDetails))
+      _ <- EitherT(persistFileDetails(fileDetails))
     } yield conversationId).value
   }
 
@@ -121,7 +121,7 @@ class SubmissionService @Inject() (
                 submissionTime = fileDetails.submitted
               )
               _ <- EitherT(addSubscriptionDetailsToXml(xml, submissionMetaData, orgContactDetails, fileDetails))
-              _ <- EitherT(persistFileDetails(fileDetails, submissionDetails))
+              _ <- EitherT(persistFileDetails(fileDetails))
             } yield conversationId
           case None =>
             val errorMessage = s"Xml file with conversation Id [${conversationId.value}] is empty"
@@ -222,10 +222,7 @@ class SubmissionService @Inject() (
       fileType
     )
 
-  private def persistFileDetails(fileDetails: FileDetails, submissionDetails: SubmissionDetails)(implicit
-    hc: HeaderCarrier,
-    fileReferenceId: String
-  ): Future[Either[BackendError, Boolean]] =
+  private def persistFileDetails(fileDetails: FileDetails): Future[Either[BackendError, Boolean]] =
     fileDetailsRepository
       .insert(fileDetails)
       .map {
@@ -245,7 +242,7 @@ class SubmissionService @Inject() (
                              error: Option[String] = None
   )(implicit
     hc: HeaderCarrier
-  ) = try {
+  ): Unit = try {
     val formattedSubmissionTime = DateTimeFormatUtil.formattedDateForAudit(submissionTime)
     val auditDetail = Audit(
       AuditDetailForFileSubmission(submissionDetails, fileReferenceId, fileStatus, formattedSubmissionTime),

--- a/it/test/repositories/submission/FileDetailsRepositorySpec.scala
+++ b/it/test/repositories/submission/FileDetailsRepositorySpec.scala
@@ -280,10 +280,8 @@ class FileDetailsRepositorySpec extends SpecBase with DefaultPlayMongoRepository
   "findStaleSubmissions" - {
     "should retrieve a stale pending submission " in {
       val oldPendingFile = fileDetails.copy(submitted = dateTimeNow.minusDays(1), name = "oldfile.xml", _id = ConversationId("conversationId777777"))
-      val oldRejectedFile = fileDetails.copy(status = RejectedSDES,
-        submitted = dateTimeNow.minusDays(1),
-        name = "oldishfile.xml",
-        _id = ConversationId("conversationId777778"))
+      val oldRejectedFile =
+        fileDetails.copy(status = RejectedSDES, submitted = dateTimeNow.minusDays(1), name = "oldishfile.xml", _id = ConversationId("conversationId777778"))
 
       val result: Future[Seq[FileDetails]] = for {
         _   <- repository.insert(fileDetails)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
   private val mongoVersion     = "2.7.0"
-  private val bootstrapVersion = "9.18.0"
+  private val bootstrapVersion = "9.19.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-backend-play-30" % bootstrapVersion,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,4 +1,4 @@
-import sbt._
+import sbt.*
 
 object AppDependencies {
   private val mongoVersion     = "2.7.0"
@@ -20,7 +20,7 @@ object AppDependencies {
     "org.mockito"            %% "mockito-scala"           % "2.0.0",
     "wolfendale"             %% "scalacheck-gen-regexp"   % "0.1.2",
     "uk.gov.hmrc"            %% "bootstrap-test-play-30"  % bootstrapVersion,
-    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-30" % mongoVersion,
+    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-30" % mongoVersion
   ).map(_ % Test)
 
   val itDependencies: Seq[ModuleID] = Seq(


### PR DESCRIPTION
Unify the error model structure by replacing `trait` implementations with `abstract class` for `BackendError` and `ApiError`. Adjusted all error case classes accordingly to streamline behavior and reduce redundancy. Also added default handling for unexpected errors in services and controllers.