### PR TITLE
DAC6-4102: Add DataExtractionStream

### DIFF
--- a/app/services/DataExtractionStream.scala
+++ b/app/services/DataExtractionStream.scala
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import models.submission.*
+import org.xml.sax.helpers.DefaultHandler
+import org.xml.sax.Attributes
+
+import javax.xml.parsers.SAXParserFactory
+import java.net.URL
+import java.time.LocalDate
+import javax.inject.Inject
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
+
+class DataExtractionStream @Inject() (implicit ec: ExecutionContext) {
+
+  def messageSpecData(xmlUrl: String): Future[Option[MessageSpecData]] =
+    Future {
+      val acc = extractStreaming(xmlUrl)
+
+      for {
+        messageId  <- acc.messageRefId
+        typeIndic  <- acc.messageTypeIndic
+        startDate  <- acc.startDate
+        endDate    <- acc.endDate
+        entityName <- acc.reportingEntityName
+      } yield MessageSpecData(
+        messageId,
+        typeIndic,
+        getReportType(typeIndic, acc),
+        startDate,
+        endDate,
+        entityName
+      )
+    }
+
+  private def extractStreaming(xmlUrl: String): Accumulator = {
+    val factory = SAXParserFactory.newInstance()
+    factory.setNamespaceAware(true)
+
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false)
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+
+    val parser  = factory.newSAXParser()
+    val handler = new MessageSpecHandler
+
+    val is = new URL(xmlUrl).openStream()
+    try parser.parse(is, handler)
+    finally is.close()
+
+    handler.result
+  }
+
+  final private case class Accumulator(
+    var messageRefId: Option[String] = None,
+    var messageTypeIndic: Option[MessageTypeIndic] = None,
+    var reportingEntityName: Option[String] = None,
+    var startDate: Option[LocalDate] = None,
+    var endDate: Option[LocalDate] = None,
+    allDocTypeIndicators: mutable.ListBuffer[String] = mutable.ListBuffer.empty,
+    reportingEntityDocTypeIndicators: mutable.ListBuffer[String] = mutable.ListBuffer.empty,
+    var seenCbcReports: Boolean = false,
+    var seenAdditionalInfo: Boolean = false,
+    var sectionDocTypeIndicators: mutable.ListBuffer[String] = mutable.ListBuffer.empty
+  )
+
+  final private class MessageSpecHandler extends DefaultHandler {
+    private val acc                = Accumulator()
+    private var path: List[String] = Nil
+    private val text               = new StringBuilder
+
+    def result: Accumulator = acc
+
+    override def startElement(
+      uri: String,
+      localName: String,
+      qName: String,
+      attributes: Attributes
+    ): Unit = {
+      val name = if (localName.nonEmpty) localName else qName
+      path = name :: path
+      text.clear()
+
+      name match {
+        case "CbcReports"     => acc.seenCbcReports = true
+        case "AdditionalInfo" => acc.seenAdditionalInfo = true
+        case _                =>
+      }
+    }
+
+    override def characters(ch: Array[Char], start: Int, length: Int): Unit =
+      text.appendAll(ch, start, length)
+
+    override def endElement(
+      uri: String,
+      localName: String,
+      qName: String
+    ): Unit = {
+      val value = text.toString.trim
+
+      path match {
+        case "MessageRefId" :: _ if value.nonEmpty =>
+          acc.messageRefId = Some(value)
+
+        case "MessageTypeIndic" :: _ if value.nonEmpty =>
+          acc.messageTypeIndic = Some(MessageTypeIndic.fromString(value))
+
+        case "Name" :: "Entity" :: "ReportingEntity" :: _ if value.nonEmpty =>
+          acc.reportingEntityName = Some(value)
+
+        case "StartDate" :: "ReportingPeriod" :: _ if value.nonEmpty =>
+          acc.startDate = Some(LocalDate.parse(value))
+
+        case "EndDate" :: "ReportingPeriod" :: _ if value.nonEmpty =>
+          acc.endDate = Some(LocalDate.parse(value))
+
+        case "DocTypeIndic" :: "DocSpec" :: "ReportingEntity" :: _ if value.nonEmpty =>
+          acc.reportingEntityDocTypeIndicators += value
+          acc.allDocTypeIndicators += value
+
+        case "DocTypeIndic" :: "DocSpec" :: "AdditionalInfo" :: _ if value.nonEmpty =>
+          acc.sectionDocTypeIndicators += value
+          acc.allDocTypeIndicators += value
+
+        case "DocTypeIndic" :: "DocSpec" :: "CbcReports" :: _ if value.nonEmpty =>
+          acc.sectionDocTypeIndicators += value
+          acc.allDocTypeIndicators += value
+
+        case "DocTypeIndic" :: _ if value.nonEmpty =>
+          acc.allDocTypeIndicators += value
+
+        case _ =>
+      }
+
+      path = path.tail
+      text.clear()
+    }
+
+  }
+
+  private def getReportType(
+    messageTypeIndicator: MessageTypeIndic,
+    acc: Accumulator
+  ): ReportType = {
+
+    val testDataIndicators = Set("OECD10", "OECD11", "OECD12", "OECD13")
+
+    // 1. Test data
+    if (acc.allDocTypeIndicators.exists(testDataIndicators.contains)) {
+      TestData
+    }
+
+    // 2. Deletion dominates everything
+    else if (acc.reportingEntityDocTypeIndicators.contains("OECD3")) {
+      DeletionOfAllInformation
+    }
+
+    // 3. Correction / deletion context if sections exist
+    else if (acc.seenCbcReports || acc.seenAdditionalInfo) {
+      val unique = acc.sectionDocTypeIndicators.distinct
+
+      (unique.length, unique.headOption) match {
+        case (1, Some("OECD2")) =>
+          CorrectionForExistingReport
+
+        case (1, Some("OECD3")) if acc.reportingEntityDocTypeIndicators.contains("OECD0") =>
+          DeletionForExistingReport
+
+        case _ =>
+          CorrectionAndDeletionForExistingReport
+      }
+    }
+
+    // 4. CBC401 new-information logic (only if no correction sections)
+    else if (messageTypeIndicator == CBC401 && acc.reportingEntityDocTypeIndicators.nonEmpty) {
+      if (acc.reportingEntityDocTypeIndicators.contains("OECD1")) {
+        NewInformation
+      } else {
+        NewInformationForExistingReport
+      }
+    }
+
+    // 5. Fallback
+    else {
+      CorrectionForReportingEntity
+    }
+  }
+
+}

--- a/app/services/validation/UploadedXmlValidationEngine.scala
+++ b/app/services/validation/UploadedXmlValidationEngine.scala
@@ -26,14 +26,14 @@ import services.DataExtractionStream
 
 import javax.inject.Inject
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class UploadedXmlValidationEngine @Inject() (xmlValidationService: XMLValidationService,
                                              xmlErrorMessageHelper: XmlErrorMessageHelper,
                                              dataExtraction: DataExtractionStream,
                                              appConfig: AppConfig
-) extends Logging {
+)(implicit ec: ExecutionContext)
+    extends Logging {
 
   def validateUploadSubmission(upScanUrl: String): Future[SubmissionValidationResult] =
     try

--- a/app/services/validation/UploadedXmlValidationEngine.scala
+++ b/app/services/validation/UploadedXmlValidationEngine.scala
@@ -19,36 +19,36 @@ package services.validation
 import config.AppConfig
 import helpers.XmlErrorMessageHelper
 import models.submission.MessageSpecData
-import models.validation._
+import models.validation.*
 import org.xml.sax.SAXParseException
 import play.api.Logging
-import services.DataExtraction
+import services.DataExtractionStream
 
 import javax.inject.Inject
 import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.xml.Elem
 
 class UploadedXmlValidationEngine @Inject() (xmlValidationService: XMLValidationService,
                                              xmlErrorMessageHelper: XmlErrorMessageHelper,
-                                             dataExtraction: DataExtraction,
+                                             dataExtraction: DataExtractionStream,
                                              appConfig: AppConfig
 ) extends Logging {
 
   def validateUploadSubmission(upScanUrl: String): Future[SubmissionValidationResult] =
     try
-      performXmlValidation(upScanUrl) match {
+      performXmlValidation(upScanUrl) map {
         case Right(messageSpecData) =>
           messageSpecData match {
-            case Some(msd) => Future.successful(SubmissionValidationSuccess(msd))
+            case Some(msd) => SubmissionValidationSuccess(msd)
             case None =>
               val errorMessage = "Could not retrieve messageSpec information from the submission"
               logger.warn(errorMessage)
-              Future.successful(InvalidXmlError(errorMessage))
+              InvalidXmlError(errorMessage)
           }
 
         case Left(errors) =>
-          Future.successful(SubmissionValidationFailure(ValidationErrors(errors)))
+          SubmissionValidationFailure(ValidationErrors(errors))
       }
     catch {
       case e: SAXParseException =>
@@ -56,11 +56,9 @@ class UploadedXmlValidationEngine @Inject() (xmlValidationService: XMLValidation
         Future.successful(InvalidXmlError(e.getMessage))
     }
 
-  def performXmlValidation(upScanUrl: String): Either[List[GenericError], Option[MessageSpecData]] = {
-    val xmlOrErrors: Either[ListBuffer[SaxParseError], Elem] = xmlValidationService.validate(upScanUrl, appConfig.fileUploadXSDFilePath)
-    xmlOrErrors match {
-      case Right(xml) => Right(dataExtraction.messageSpecData(xml))
-      case Left(list) => Left(xmlErrorMessageHelper.generateErrorMessages(list))
+  def performXmlValidation(upScanUrl: String): Future[Either[List[GenericError], Option[MessageSpecData]]] =
+    xmlValidationService.validateUrlStreamAsync(upScanUrl, appConfig.fileUploadXSDFilePath) flatMap {
+      case Right(_)   => dataExtraction.messageSpecData(upScanUrl).map(Right(_))
+      case Left(list) => Future.successful(Left(xmlErrorMessageHelper.generateErrorMessages(ListBuffer.from(list))))
     }
-  }
 }

--- a/app/services/validation/XMLValidationService.scala
+++ b/app/services/validation/XMLValidationService.scala
@@ -21,7 +21,7 @@ import org.xml.sax.{ErrorHandler, SAXParseException}
 import org.xml.sax.helpers.DefaultHandler
 
 import java.io.{InputStream, StringReader}
-import java.net.URL
+import java.net.{URI, URL}
 import javax.inject.Inject
 import javax.xml.parsers.{SAXParser, SAXParserFactory}
 import javax.xml.transform.stream.StreamSource
@@ -79,7 +79,7 @@ class XMLValidationService @Inject() () {
 
   def validateUrlStreamAsync(upScanUrl: String, xsdResourcePath: String)(implicit ec: ExecutionContext): Future[Either[List[SaxParseError], Unit]] =
     Future {
-      Using.resource(new URL(upScanUrl).openStream()) { is =>
+      Using.resource(new URI(upScanUrl).toURL.openStream()) { is =>
         validateStream(is, xsdResourcePath)
       }
     }

--- a/test/services/validation/UploadedXmlValidationEngineSpec.scala
+++ b/test/services/validation/UploadedXmlValidationEngineSpec.scala
@@ -20,13 +20,13 @@ import base.SpecBase
 import config.AppConfig
 import helpers.XmlErrorMessageHelper
 import models.submission.{CBC401, MessageSpecData, NewInformation}
-import models.validation._
+import models.validation.*
 import org.mockito.ArgumentMatchers.any
-import services.DataExtraction
+import services.DataExtractionStream
 
 import java.time.LocalDate
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.Await
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.DurationInt
 import scala.xml.Elem
 
@@ -133,7 +133,7 @@ class UploadedXmlValidationEngineSpec extends SpecBase {
     val mockXmlValidationService: XMLValidationService   = mock[XMLValidationService]
     val mockXmlErrorMessageHelper: XmlErrorMessageHelper = new XmlErrorMessageHelper
     val appConfig: AppConfig                             = app.injector.instanceOf[AppConfig]
-    val mockDataExtraction: DataExtraction               = mock[DataExtraction]
+    val mockDataExtraction: DataExtractionStream         = mock[DataExtractionStream]
 
     val validationEngine = new UploadedXmlValidationEngine(mockXmlValidationService, mockXmlErrorMessageHelper, mockDataExtraction, appConfig)
 
@@ -146,16 +146,16 @@ class UploadedXmlValidationEngineSpec extends SpecBase {
 
     "must return UploadSubmissionValidationSuccess when xml with no errors received" in new SetUp {
 
-      when(mockXmlValidationService.validate(any[String](), any[String]())).thenReturn(Right(elem))
-      when(mockDataExtraction.messageSpecData(any[Elem])).thenReturn(Some(messageSpecData))
+      when(mockXmlValidationService.validateUrlStreamAsync(any[String](), any[String]())(any[ExecutionContext]())).thenReturn(Future.successful(Right(())))
+      when(mockDataExtraction.messageSpecData(any[String])).thenReturn(Future.successful(Some(messageSpecData)))
 
       Await.result(validationEngine.validateUploadSubmission(source), 10.seconds) mustBe SubmissionValidationSuccess(messageSpecData)
     }
 
     "must return ValidationFailure for file which multiple pieces of mandatory information missing" in new SetUp {
 
-      when(mockXmlValidationService.validate(any[String](), any[String]()))
-        .thenReturn(Left(ListBuffer(typeError1, typeError2, summaryError1, summaryError2)))
+      when(mockXmlValidationService.validateUrlStreamAsync(any[String](), any[String]())(any[ExecutionContext]()))
+        .thenReturn(Future.successful(Left(List(typeError1, typeError2, summaryError1, summaryError2))))
 
       val expectedErrors =
         Seq(GenericError(176, Message("xml.empty.field", List("Entity"))), GenericError(258, Message("xml.add.a.element", List("Summary"))))
@@ -167,7 +167,8 @@ class UploadedXmlValidationEngineSpec extends SpecBase {
 
       val missingAttributeError: SaxParseError = SaxParseError(175, "cvc-complex-type.4: Attribute 'currCode' must appear on element 'Amount'.")
 
-      when(mockXmlValidationService.validate(any[String](), any[String]())).thenReturn(Left(ListBuffer(missingAttributeError)))
+      when(mockXmlValidationService.validateUrlStreamAsync(any[String](), any[String]())(any[ExecutionContext]()))
+        .thenReturn(Future.successful(Left(List(missingAttributeError))))
 
       val expectedErrors = Seq(GenericError(175, Message("xml.add.attribute", List("Amount currCode"))))
 
@@ -176,8 +177,8 @@ class UploadedXmlValidationEngineSpec extends SpecBase {
 
     "must return ValidationFailure for file where element is too long (1-400 allowed)" in new SetUp {
 
-      when(mockXmlValidationService.validate(any[String](), any[String]()))
-        .thenReturn(Left(ListBuffer(maxLengthError1, maxlengthError2)))
+      when(mockXmlValidationService.validateUrlStreamAsync(any[String](), any[String]())(any[ExecutionContext]()))
+        .thenReturn(Future.successful(Left(List(maxLengthError1, maxlengthError2))))
 
       val expectedErrors = Seq(GenericError(116, Message("xml.not.allowed.length", List("BuildingIdentifier", "400"))))
 
@@ -186,8 +187,8 @@ class UploadedXmlValidationEngineSpec extends SpecBase {
 
     "must return ValidationFailure for file where element is too long (1-4000 allowed) and show the number correctly formatted" in new SetUp {
 
-      when(mockXmlValidationService.validate(any[String](), any[String]()))
-        .thenReturn(Left(ListBuffer(maxLengthError3, maxlengthError4)))
+      when(mockXmlValidationService.validateUrlStreamAsync(any[String](), any[String]())(any[ExecutionContext]()))
+        .thenReturn(Future.successful(Left(List(maxLengthError3, maxlengthError4))))
 
       val expectedErrors = Seq(GenericError(116, Message("xml.not.allowed.length", List("NationalProvision", "4,000"))))
 
@@ -196,8 +197,8 @@ class UploadedXmlValidationEngineSpec extends SpecBase {
 
     "must return ValidationFailure for file with invalid country code" in new SetUp {
 
-      when(mockXmlValidationService.validate(any[String](), any[String]()))
-        .thenReturn(Left(ListBuffer(countryCodeError1, countryCodeError2)))
+      when(mockXmlValidationService.validateUrlStreamAsync(any[String](), any[String]())(any[ExecutionContext]()))
+        .thenReturn(Future.successful(Left(List(countryCodeError1, countryCodeError2))))
 
       val expectedErrors = Seq(GenericError(123, Message("xml.not.ISO.code.elem", List("CountryCode"))))
 
@@ -206,8 +207,8 @@ class UploadedXmlValidationEngineSpec extends SpecBase {
 
     "must return ValidationFailure for file with invalid ResCountryCode" in new SetUp {
 
-      when(mockXmlValidationService.validate(any[String](), any[String]()))
-        .thenReturn(Left(ListBuffer(countryExemptionError1, countryExemptionError2)))
+      when(mockXmlValidationService.validateUrlStreamAsync(any[String](), any[String]())(any[ExecutionContext]()))
+        .thenReturn(Future.successful(Left(List(countryExemptionError1, countryExemptionError2))))
 
       val expectedErrors = Seq(GenericError(133, Message("xml.not.ISO.code.elem", List("ResCountryCode"))))
 
@@ -216,8 +217,8 @@ class UploadedXmlValidationEngineSpec extends SpecBase {
 
     "must return ValidationFailure for file with invalid ReportingRole code" in new SetUp {
 
-      when(mockXmlValidationService.validate(any[String](), any[String]()))
-        .thenReturn(Left(ListBuffer(reasonError1, reasonError2)))
+      when(mockXmlValidationService.validateUrlStreamAsync(any[String](), any[String]())(any[ExecutionContext]()))
+        .thenReturn(Future.successful(Left(List(reasonError1, reasonError2))))
 
       val expectedErrors = Seq(GenericError(169, Message("xml.not.allowed.value", List("ReportingRole"))))
 
@@ -226,8 +227,8 @@ class UploadedXmlValidationEngineSpec extends SpecBase {
 
     "must return ValidationFailure for file with invalid issuedBy code" in new SetUp {
 
-      when(mockXmlValidationService.validate(any[String](), any[String]()))
-        .thenReturn(Left(ListBuffer(issuedByError1, issuedByError2)))
+      when(mockXmlValidationService.validateUrlStreamAsync(any[String](), any[String]())(any[ExecutionContext]()))
+        .thenReturn(Future.successful(Left(List(issuedByError1, issuedByError2))))
 
       val expectedErrors = Seq(GenericError(18, Message("xml.not.ISO.code", List("TIN issuedBy"))))
 
@@ -237,7 +238,8 @@ class UploadedXmlValidationEngineSpec extends SpecBase {
     "must return ValidationFailure with generic error message if parse error is not in an expected format" in new SetUp {
 
       val randomParseError: SaxParseError = SaxParseError(lineNumber, xsdError)
-      when(mockXmlValidationService.validate(any[String](), any[String]())).thenReturn(Left(ListBuffer(randomParseError)))
+      when(mockXmlValidationService.validateUrlStreamAsync(any[String](), any[String]())(any[ExecutionContext]()))
+        .thenReturn(Future.successful(Left(List(randomParseError))))
 
       val expectedErrors = Seq(GenericError(lineNumber, Message("xml.defaultMessage")))
 

--- a/test/services/validation/UploadedXmlValidationEngineSpec.scala
+++ b/test/services/validation/UploadedXmlValidationEngineSpec.scala
@@ -29,6 +29,7 @@ import scala.collection.mutable.ListBuffer
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.DurationInt
 import scala.xml.Elem
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class UploadedXmlValidationEngineSpec extends SpecBase {
 

--- a/test/services/validation/XmlValidationServiceSpec.scala
+++ b/test/services/validation/XmlValidationServiceSpec.scala
@@ -18,6 +18,8 @@ package services.validation
 
 import base.SpecBase
 import models.validation.SaxParseError
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.collection.mutable.ListBuffer
 import scala.xml.XML
@@ -86,6 +88,26 @@ class XmlValidationServiceSpec extends SpecBase {
       val validSubmission = XML.loadFile("test/resources/cbc/fileUpload/validcbc_empty.xml")
 
       val result = service.validate(validSubmission, xsdPath)
+
+      result.isLeft mustBe true
+    }
+
+    "must correctly validate a streaming submission" in {
+      val service = app.injector.instanceOf[XMLValidationService]
+
+      val xmlUrl = getClass.getResource("/cbc/fileUpload/validcbc.xml").toURI.toString
+
+      val result = await(service.validateUrlStreamAsync(xmlUrl, xsdPath))
+
+      result.isLeft mustBe false
+    }
+
+    "must correctly validate a streaming submission with empty value" in {
+      val service = app.injector.instanceOf[XMLValidationService]
+
+      val xmlUrl = getClass.getResource("/cbc/fileUpload/validcbc_empty.xml").toURI.toString
+
+      val result = await(service.validateUrlStreamAsync(xmlUrl, xsdPath))
 
       result.isLeft mustBe true
     }


### PR DESCRIPTION
Introduce `DataExtractionStream` for XML data extraction with streaming support to improve efficiency and performance. Updated `XMLValidationService` and related components to integrate with the new service. Added tests to verify correctness of the service and its integration.